### PR TITLE
Block Count updates on block snap and unsnap.

### DIFF
--- a/Assets/Blocks/Scripts/BlockSnapping.cs
+++ b/Assets/Blocks/Scripts/BlockSnapping.cs
@@ -5,9 +5,17 @@ using UnityEngine.XR.Interaction.Toolkit;
 public class BlockSnapping : MonoBehaviour
 {
     private bool hasSnapped = false; // Flag to prevent repeated snapping
+    private QueueReading queueReading;
 
     private void Awake()
     {
+        // Automatic detection of QueueReading component
+        queueReading = FindObjectOfType<QueueReading>();
+        if (queueReading == null)
+        {
+            Debug.LogWarning("QueueReading component not found in the scene. Ensure there is one active in the hierarchy.");
+        }
+
         // Collision Forwarding active
         Transform snapTriggerTop = transform.Find("SnapTriggerTop");
         AttachCollisionForwarding(snapTriggerTop);
@@ -94,6 +102,8 @@ public class BlockSnapping : MonoBehaviour
         }
 
         Debug.Log($"{block2.name} snapped to {block1.name}.");
+
+        queueReading?.ReadQueue(); // Update Block Queue on snap.
     }
 
     private void OnGrab(SelectEnterEventArgs args)
@@ -148,6 +158,7 @@ public class BlockSnapping : MonoBehaviour
     private IEnumerator ResetSnapStatusAfterDelay()
     {
         yield return new WaitForSeconds(0.5f); // Wait for 0.5 seconds (change as needed)
+        queueReading?.ReadQueue(); // Update Block Queue on unsnap.
         hasSnapped = false; // Allow snapping again after a delay
         Debug.Log($"Snapping re-enabled on: {gameObject.name}");
     }

--- a/Assets/Scenes/Basic Level View.unity
+++ b/Assets/Scenes/Basic Level View.unity
@@ -4736,12 +4736,12 @@ MonoBehaviour:
   m_margin: {x: -0.03583335, y: -28.862024, z: -9.593889, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_renderer: {fileID: 740480789}
-  m_maskType: 0
   _SortingLayer: 0
   _SortingLayerID: 0
   _SortingOrder: 0
+  m_hasFontAssetChanged: 0
+  m_renderer: {fileID: 740480789}
+  m_maskType: 0
 --- !u!23 &740480789
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -6289,11 +6289,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ad818c36731146e994540a1896ad8f24, type: 3}
---- !u!4 &976852638 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 973429309785621390, guid: a7d3bc7275f2278409e2fcc4a4982ca8, type: 3}
-  m_PrefabInstance: {fileID: 520813208786846585}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &984974739
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7748,7 +7743,7 @@ MonoBehaviour:
   m_SelectEntered:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 1108144157}
+      - m_Target: {fileID: 0}
         m_TargetAssemblyTypeName: TurtleMovement, Assembly-CSharp
         m_MethodName: StartQueue
         m_Mode: 1
@@ -7933,7 +7928,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 839e8ec8ed89e713a9c7cbec41e8e73e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  turtleMovement: {fileID: 1108144157}
+  turtleMovement: {fileID: 0}
   blockWalker: {fileID: 1866267873}
 --- !u!1 &1176638032
 GameObject:
@@ -8899,23 +8894,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 400000, guid: 23f69f763336f67488996af0a5d95f78, type: 3}
   m_PrefabInstance: {fileID: 1298509439}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1299240288 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7837417723290813568, guid: a7d3bc7275f2278409e2fcc4a4982ca8, type: 3}
-  m_PrefabInstance: {fileID: 520813208786846585}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1299240292
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1299240288}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cfa0bb0545cb23344a907b689c68e9f2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1299343378
 GameObject:
   m_ObjectHideFlags: 0
@@ -10211,23 +10189,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1463806825}
   m_Mesh: {fileID: -263479259522566461, guid: 40e95b051df24428f834cda5561cadfa, type: 3}
---- !u!1 &1467941250 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 2573627914445360027, guid: a7d3bc7275f2278409e2fcc4a4982ca8, type: 3}
-  m_PrefabInstance: {fileID: 520813208786846585}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1467941251
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1467941250}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4cf55196b48accc4bb66553c47f1fa70, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1488688689
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -12334,7 +12295,6 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 976852638}
   - {fileID: 1866267871}
   - {fileID: 79738552}
   - {fileID: 1097122006887147351}
@@ -12795,7 +12755,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2724822605195957764, guid: 5619ccd8f57d4ae9eadafa60b02da6cd, type: 3}
       propertyPath: m_UseGravity
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6122732868338158301, guid: 5619ccd8f57d4ae9eadafa60b02da6cd, type: 3}
       propertyPath: m_Name
@@ -14675,77 +14635,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 400000, guid: 23f69f763336f67488996af0a5d95f78, type: 3}
   m_PrefabInstance: {fileID: 2124615041}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &520813208786846585
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1763928935}
-    m_Modifications:
-    - target: {fileID: 973429309785621390, guid: a7d3bc7275f2278409e2fcc4a4982ca8, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -2.946
-      objectReference: {fileID: 0}
-    - target: {fileID: 973429309785621390, guid: a7d3bc7275f2278409e2fcc4a4982ca8, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 1.434
-      objectReference: {fileID: 0}
-    - target: {fileID: 973429309785621390, guid: a7d3bc7275f2278409e2fcc4a4982ca8, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 2.396
-      objectReference: {fileID: 0}
-    - target: {fileID: 973429309785621390, guid: a7d3bc7275f2278409e2fcc4a4982ca8, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 973429309785621390, guid: a7d3bc7275f2278409e2fcc4a4982ca8, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 973429309785621390, guid: a7d3bc7275f2278409e2fcc4a4982ca8, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 973429309785621390, guid: a7d3bc7275f2278409e2fcc4a4982ca8, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 973429309785621390, guid: a7d3bc7275f2278409e2fcc4a4982ca8, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 973429309785621390, guid: a7d3bc7275f2278409e2fcc4a4982ca8, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 973429309785621390, guid: a7d3bc7275f2278409e2fcc4a4982ca8, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2573627914445360027, guid: a7d3bc7275f2278409e2fcc4a4982ca8, type: 3}
-      propertyPath: m_Name
-      value: Queue (Physics Tester)
-      objectReference: {fileID: 0}
-    - target: {fileID: 2573627914445360027, guid: a7d3bc7275f2278409e2fcc4a4982ca8, type: 3}
-      propertyPath: m_TagString
-      value: Block
-      objectReference: {fileID: 0}
-    - target: {fileID: 7837417723290813568, guid: a7d3bc7275f2278409e2fcc4a4982ca8, type: 3}
-      propertyPath: m_TagString
-      value: Untagged
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 2573627914445360027, guid: a7d3bc7275f2278409e2fcc4a4982ca8, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1467941251}
-    - targetCorrespondingSourceObject: {fileID: 7837417723290813568, guid: a7d3bc7275f2278409e2fcc4a4982ca8, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1299240292}
-  m_SourcePrefab: {fileID: 100100000, guid: a7d3bc7275f2278409e2fcc4a4982ca8, type: 3}
 --- !u!4 &1097122006887147351 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6916470085308465810, guid: ea0469b6216597c4bb8062100be0b2e1, type: 3}


### PR DESCRIPTION
SnapToBlock() and ResetSnapStatusAfterDelay() now both call queueReading.ReadQueue(), allowing the Block Count to update dynamically. Only one QueueReading script must exist in a scene for this to work properly. Causes excessive debug text each snap, will trim down soon.