### PR TITLE
Added column splitting, updated block physics/scripts

### DIFF
--- a/Assets/Blocks/Prefabs/Block (FALSE).prefab
+++ b/Assets/Blocks/Prefabs/Block (FALSE).prefab
@@ -231,6 +231,37 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1389943061981320986}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3282031847488521628
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 23955695754276042}
+  m_Layer: 0
+  m_Name: AttachPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &23955695754276042
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3282031847488521628}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.5}
+  m_LocalScale: {x: 2, y: 4, z: 2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1389943061981320986}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6632366837083905868
 GameObject:
   m_ObjectHideFlags: 0
@@ -339,7 +370,7 @@ Transform:
   m_GameObject: {fileID: 6713015538121544575}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 1.942, y: 0.303, z: 2}
+  m_LocalPosition: {x: 2, y: 0.5, z: 2}
   m_LocalScale: {x: 0.5, y: 0.25, z: 0.5}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -348,6 +379,7 @@ Transform:
   - {fileID: 8009763825008059073}
   - {fileID: 9075289025122379036}
   - {fileID: 9140502789084385113}
+  - {fileID: 23955695754276042}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &6176100348886939945
@@ -550,7 +582,7 @@ MonoBehaviour:
   m_OnDeactivate:
     m_PersistentCalls:
       m_Calls: []
-  m_AttachTransform: {fileID: 0}
+  m_AttachTransform: {fileID: 23955695754276042}
   m_SecondaryAttachTransform: {fileID: 0}
   m_UseDynamicAttach: 0
   m_MatchAttachPosition: 1
@@ -575,7 +607,7 @@ MonoBehaviour:
   m_SmoothScale: 0
   m_SmoothScaleAmount: 8
   m_TightenScale: 0.1
-  m_ThrowOnDetach: 1
+  m_ThrowOnDetach: 0
   m_ThrowSmoothingDuration: 0.25
   m_ThrowSmoothingCurve:
     serializedVersion: 2

--- a/Assets/Blocks/Prefabs/Block (GOTO).prefab
+++ b/Assets/Blocks/Prefabs/Block (GOTO).prefab
@@ -231,6 +231,37 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1389943061981320986}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4015535945074277964
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6540187735458940746}
+  m_Layer: 0
+  m_Name: AttachPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6540187735458940746
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4015535945074277964}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.5}
+  m_LocalScale: {x: 2, y: 4, z: 2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1389943061981320986}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6632366837083905868
 GameObject:
   m_ObjectHideFlags: 0
@@ -340,7 +371,7 @@ Transform:
   m_GameObject: {fileID: 6713015538121544575}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 1.942, y: 0.303, z: 2}
+  m_LocalPosition: {x: 2, y: 0.5, z: 2}
   m_LocalScale: {x: 0.5, y: 0.25, z: 0.5}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -350,6 +381,7 @@ Transform:
   - {fileID: 8009763825008059073}
   - {fileID: 9075289025122379036}
   - {fileID: 9140502789084385113}
+  - {fileID: 6540187735458940746}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &6176100348886939945
@@ -552,7 +584,7 @@ MonoBehaviour:
   m_OnDeactivate:
     m_PersistentCalls:
       m_Calls: []
-  m_AttachTransform: {fileID: 0}
+  m_AttachTransform: {fileID: 6540187735458940746}
   m_SecondaryAttachTransform: {fileID: 0}
   m_UseDynamicAttach: 0
   m_MatchAttachPosition: 1
@@ -577,7 +609,7 @@ MonoBehaviour:
   m_SmoothScale: 0
   m_SmoothScaleAmount: 8
   m_TightenScale: 0.1
-  m_ThrowOnDetach: 1
+  m_ThrowOnDetach: 0
   m_ThrowSmoothingDuration: 0.25
   m_ThrowSmoothingCurve:
     serializedVersion: 2

--- a/Assets/Blocks/Prefabs/Block (IfBegin).prefab
+++ b/Assets/Blocks/Prefabs/Block (IfBegin).prefab
@@ -339,7 +339,7 @@ Transform:
   m_GameObject: {fileID: 6713015538121544575}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 1.942, y: 0.303, z: 2}
+  m_LocalPosition: {x: 2, y: 0.5, z: 2}
   m_LocalScale: {x: 0.5, y: 0.25, z: 0.5}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -348,6 +348,7 @@ Transform:
   - {fileID: 8009763825008059073}
   - {fileID: 9075289025122379036}
   - {fileID: 9140502789084385113}
+  - {fileID: 8238658436870516517}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &6176100348886939945
@@ -550,7 +551,7 @@ MonoBehaviour:
   m_OnDeactivate:
     m_PersistentCalls:
       m_Calls: []
-  m_AttachTransform: {fileID: 0}
+  m_AttachTransform: {fileID: 8238658436870516517}
   m_SecondaryAttachTransform: {fileID: 0}
   m_UseDynamicAttach: 0
   m_MatchAttachPosition: 1
@@ -575,7 +576,7 @@ MonoBehaviour:
   m_SmoothScale: 0
   m_SmoothScaleAmount: 8
   m_TightenScale: 0.1
-  m_ThrowOnDetach: 1
+  m_ThrowOnDetach: 0
   m_ThrowSmoothingDuration: 0.25
   m_ThrowSmoothingCurve:
     serializedVersion: 2
@@ -644,6 +645,37 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   floorLevel: 0
   padding: 0.1
+--- !u!1 &8621670510736045226
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8238658436870516517}
+  m_Layer: 0
+  m_Name: AttachPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8238658436870516517
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8621670510736045226}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.5}
+  m_LocalScale: {x: 2, y: 4, z: 2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1389943061981320986}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &8666319159274101146
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Blocks/Prefabs/Block (IfEnd).prefab
+++ b/Assets/Blocks/Prefabs/Block (IfEnd).prefab
@@ -231,6 +231,37 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1389943061981320986}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3534407142449023539
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7060038393742278151}
+  m_Layer: 0
+  m_Name: AttachPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7060038393742278151
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3534407142449023539}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.5}
+  m_LocalScale: {x: 2, y: 4, z: 2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1389943061981320986}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6632366837083905868
 GameObject:
   m_ObjectHideFlags: 0
@@ -339,7 +370,7 @@ Transform:
   m_GameObject: {fileID: 6713015538121544575}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 1.942, y: 0.303, z: 2}
+  m_LocalPosition: {x: 2, y: 0.5, z: 2}
   m_LocalScale: {x: 0.5, y: 0.25, z: 0.5}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -348,6 +379,7 @@ Transform:
   - {fileID: 8009763825008059073}
   - {fileID: 9075289025122379036}
   - {fileID: 9140502789084385113}
+  - {fileID: 7060038393742278151}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &6176100348886939945
@@ -550,7 +582,7 @@ MonoBehaviour:
   m_OnDeactivate:
     m_PersistentCalls:
       m_Calls: []
-  m_AttachTransform: {fileID: 0}
+  m_AttachTransform: {fileID: 7060038393742278151}
   m_SecondaryAttachTransform: {fileID: 0}
   m_UseDynamicAttach: 0
   m_MatchAttachPosition: 1
@@ -575,7 +607,7 @@ MonoBehaviour:
   m_SmoothScale: 0
   m_SmoothScaleAmount: 8
   m_TightenScale: 0.1
-  m_ThrowOnDetach: 1
+  m_ThrowOnDetach: 0
   m_ThrowSmoothingDuration: 0.25
   m_ThrowSmoothingCurve:
     serializedVersion: 2

--- a/Assets/Blocks/Prefabs/Block (Jump).prefab
+++ b/Assets/Blocks/Prefabs/Block (Jump).prefab
@@ -339,7 +339,7 @@ Transform:
   m_GameObject: {fileID: 6713015538121544575}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 1.942, y: 0.303, z: 2}
+  m_LocalPosition: {x: 2, y: 0.5, z: 2}
   m_LocalScale: {x: 0.5, y: 0.25, z: 0.5}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -348,6 +348,7 @@ Transform:
   - {fileID: 8009763825008059073}
   - {fileID: 9075289025122379036}
   - {fileID: 9140502789084385113}
+  - {fileID: 6033542856228075816}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &6176100348886939945
@@ -550,7 +551,7 @@ MonoBehaviour:
   m_OnDeactivate:
     m_PersistentCalls:
       m_Calls: []
-  m_AttachTransform: {fileID: 0}
+  m_AttachTransform: {fileID: 6033542856228075816}
   m_SecondaryAttachTransform: {fileID: 0}
   m_UseDynamicAttach: 0
   m_MatchAttachPosition: 1
@@ -575,7 +576,7 @@ MonoBehaviour:
   m_SmoothScale: 0
   m_SmoothScaleAmount: 8
   m_TightenScale: 0.1
-  m_ThrowOnDetach: 1
+  m_ThrowOnDetach: 0
   m_ThrowSmoothingDuration: 0.25
   m_ThrowSmoothingCurve:
     serializedVersion: 2
@@ -644,6 +645,37 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   floorLevel: 0
   padding: 0.1
+--- !u!1 &8338628556024756916
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6033542856228075816}
+  m_Layer: 0
+  m_Name: AttachPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6033542856228075816
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8338628556024756916}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.5}
+  m_LocalScale: {x: 2, y: 4, z: 2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1389943061981320986}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &8666319159274101146
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Blocks/Prefabs/Block (Move Forward).prefab
+++ b/Assets/Blocks/Prefabs/Block (Move Forward).prefab
@@ -66,6 +66,37 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cfa0bb0545cb23344a907b689c68e9f2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &4402291311284925986
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3280209548035707509}
+  m_Layer: 0
+  m_Name: AttachPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3280209548035707509
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4402291311284925986}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.5}
+  m_LocalScale: {x: 2, y: 4, z: 2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7868320082566465073}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &4779659384015383935
 GameObject:
   m_ObjectHideFlags: 0
@@ -367,7 +398,7 @@ Transform:
   m_GameObject: {fileID: 6122732868338158301}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -2.427996, y: 0.554, z: 1.1019714}
+  m_LocalPosition: {x: 2, y: 0.5, z: 2}
   m_LocalScale: {x: 0.5, y: 0.25, z: 0.5}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -376,6 +407,7 @@ Transform:
   - {fileID: 2147135566816312265}
   - {fileID: 616791098846811607}
   - {fileID: 3615655894428358110}
+  - {fileID: 3280209548035707509}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &6491022028017919705
@@ -578,7 +610,7 @@ MonoBehaviour:
   m_OnDeactivate:
     m_PersistentCalls:
       m_Calls: []
-  m_AttachTransform: {fileID: 0}
+  m_AttachTransform: {fileID: 3280209548035707509}
   m_SecondaryAttachTransform: {fileID: 0}
   m_UseDynamicAttach: 0
   m_MatchAttachPosition: 1
@@ -603,7 +635,7 @@ MonoBehaviour:
   m_SmoothScale: 0
   m_SmoothScaleAmount: 8
   m_TightenScale: 0.1
-  m_ThrowOnDetach: 1
+  m_ThrowOnDetach: 0
   m_ThrowSmoothingDuration: 0.25
   m_ThrowSmoothingCurve:
     serializedVersion: 2

--- a/Assets/Blocks/Prefabs/Block (Rotate Left).prefab
+++ b/Assets/Blocks/Prefabs/Block (Rotate Left).prefab
@@ -33,7 +33,7 @@ Transform:
   m_GameObject: {fileID: 252830763283630294}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.921, y: 0.303, z: 2}
+  m_LocalPosition: {x: 2, y: 0.5, z: 2}
   m_LocalScale: {x: 0.5, y: 0.25, z: 0.5}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -42,6 +42,7 @@ Transform:
   - {fileID: 1600547730685061411}
   - {fileID: 8560305111300701359}
   - {fileID: 4123387920330152059}
+  - {fileID: 1713139324832816466}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1486243143380554105
@@ -244,7 +245,7 @@ MonoBehaviour:
   m_OnDeactivate:
     m_PersistentCalls:
       m_Calls: []
-  m_AttachTransform: {fileID: 0}
+  m_AttachTransform: {fileID: 1713139324832816466}
   m_SecondaryAttachTransform: {fileID: 0}
   m_UseDynamicAttach: 0
   m_MatchAttachPosition: 1
@@ -269,7 +270,7 @@ MonoBehaviour:
   m_SmoothScale: 0
   m_SmoothScaleAmount: 8
   m_TightenScale: 0.1
-  m_ThrowOnDetach: 1
+  m_ThrowOnDetach: 0
   m_ThrowSmoothingDuration: 0.25
   m_ThrowSmoothingCurve:
     serializedVersion: 2
@@ -671,6 +672,37 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: -0.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5117134346361345392}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5741263941743319584
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1713139324832816466}
+  m_Layer: 0
+  m_Name: AttachPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1713139324832816466
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5741263941743319584}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.5}
+  m_LocalScale: {x: 2, y: 4, z: 2}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5117134346361345392}

--- a/Assets/Blocks/Prefabs/Block (Rotate Right).prefab
+++ b/Assets/Blocks/Prefabs/Block (Rotate Right).prefab
@@ -33,7 +33,7 @@ Transform:
   m_GameObject: {fileID: 2595958130031381277}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.973, y: 0.303, z: 2}
+  m_LocalPosition: {x: 2, y: 0.5, z: 2}
   m_LocalScale: {x: 0.5, y: 0.25, z: 0.5}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -42,6 +42,7 @@ Transform:
   - {fileID: 3225595921274934994}
   - {fileID: 903497282658625208}
   - {fileID: 6930945477157114027}
+  - {fileID: 6028037609966319242}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &6299180831296131140
@@ -244,7 +245,7 @@ MonoBehaviour:
   m_OnDeactivate:
     m_PersistentCalls:
       m_Calls: []
-  m_AttachTransform: {fileID: 0}
+  m_AttachTransform: {fileID: 6028037609966319242}
   m_SecondaryAttachTransform: {fileID: 0}
   m_UseDynamicAttach: 0
   m_MatchAttachPosition: 1
@@ -269,7 +270,7 @@ MonoBehaviour:
   m_SmoothScale: 0
   m_SmoothScaleAmount: 8
   m_TightenScale: 0.1
-  m_ThrowOnDetach: 1
+  m_ThrowOnDetach: 0
   m_ThrowSmoothingDuration: 0.25
   m_ThrowSmoothingCurve:
     serializedVersion: 2
@@ -404,6 +405,37 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cfa0bb0545cb23344a907b689c68e9f2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &4089590454894535182
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6028037609966319242}
+  m_Layer: 0
+  m_Name: AttachPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6028037609966319242
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4089590454894535182}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.5}
+  m_LocalScale: {x: 2, y: 4, z: 2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6916470085308465810}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6111736414079811001
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Blocks/Prefabs/Block (StartQueue).prefab
+++ b/Assets/Blocks/Prefabs/Block (StartQueue).prefab
@@ -66,37 +66,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cfa0bb0545cb23344a907b689c68e9f2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &4779659384015383935
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2147135566816312265}
-  m_Layer: 0
-  m_Name: SnapPointTop
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2147135566816312265
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4779659384015383935}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.5, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 7868320082566465073}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &4889191840042558666
 GameObject:
   m_ObjectHideFlags: 0
@@ -367,15 +336,14 @@ Transform:
   m_GameObject: {fileID: 6122732868338158301}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -2.427996, y: 0.554, z: 1.1019714}
+  m_LocalPosition: {x: 2, y: 0.5, z: 2}
   m_LocalScale: {x: 0.5, y: 0.25, z: 0.5}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 4876165595623705379}
   - {fileID: 605047917051539519}
-  - {fileID: 2147135566816312265}
   - {fileID: 616791098846811607}
   - {fileID: 3615655894428358110}
+  - {fileID: 1692367171048213189}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &6491022028017919705
@@ -471,7 +439,7 @@ Rigidbody:
     m_Bits: 0
   m_ImplicitCom: 1
   m_ImplicitTensor: 1
-  m_UseGravity: 1
+  m_UseGravity: 0
   m_IsKinematic: 0
   m_Interpolate: 0
   m_Constraints: 0
@@ -578,7 +546,7 @@ MonoBehaviour:
   m_OnDeactivate:
     m_PersistentCalls:
       m_Calls: []
-  m_AttachTransform: {fileID: 0}
+  m_AttachTransform: {fileID: 1692367171048213189}
   m_SecondaryAttachTransform: {fileID: 0}
   m_UseDynamicAttach: 0
   m_MatchAttachPosition: 1
@@ -603,7 +571,7 @@ MonoBehaviour:
   m_SmoothScale: 0
   m_SmoothScaleAmount: 8
   m_TightenScale: 0.1
-  m_ThrowOnDetach: 1
+  m_ThrowOnDetach: 0
   m_ThrowSmoothingDuration: 0.25
   m_ThrowSmoothingCurve:
     serializedVersion: 2
@@ -778,7 +746,7 @@ Transform:
   m_Children: []
   m_Father: {fileID: 7868320082566465073}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &9187168534958783521
+--- !u!1 &8382109396339175297
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -786,62 +754,26 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 4876165595623705379}
-  - component: {fileID: 3878166236413959434}
-  - component: {fileID: 5646213506522335669}
+  - component: {fileID: 1692367171048213189}
   m_Layer: 0
-  m_Name: SnapTriggerTop
+  m_Name: AttachPoint
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &4876165595623705379
+--- !u!4 &1692367171048213189
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9187168534958783521}
+  m_GameObject: {fileID: 8382109396339175297}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.486, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.5}
+  m_LocalScale: {x: 2, y: 4, z: 2}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7868320082566465073}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!65 &3878166236413959434
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9187168534958783521}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 1
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 0.5, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!114 &5646213506522335669
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9187168534958783521}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 65363b0380395e24b9c3462900c6e7c3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  parentBlockSnapping: {fileID: 0}

--- a/Assets/Blocks/Prefabs/Block (TRUE).prefab
+++ b/Assets/Blocks/Prefabs/Block (TRUE).prefab
@@ -231,6 +231,37 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1389943061981320986}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3375559482828427965
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3856406799651127792}
+  m_Layer: 0
+  m_Name: AttachPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3856406799651127792
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3375559482828427965}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.5}
+  m_LocalScale: {x: 2, y: 4, z: 2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1389943061981320986}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6632366837083905868
 GameObject:
   m_ObjectHideFlags: 0
@@ -339,7 +370,7 @@ Transform:
   m_GameObject: {fileID: 6713015538121544575}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 1.942, y: 0.303, z: 2}
+  m_LocalPosition: {x: 2, y: 0.5, z: 2}
   m_LocalScale: {x: 0.5, y: 0.25, z: 0.5}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -348,6 +379,7 @@ Transform:
   - {fileID: 8009763825008059073}
   - {fileID: 9075289025122379036}
   - {fileID: 9140502789084385113}
+  - {fileID: 3856406799651127792}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &6176100348886939945
@@ -550,7 +582,7 @@ MonoBehaviour:
   m_OnDeactivate:
     m_PersistentCalls:
       m_Calls: []
-  m_AttachTransform: {fileID: 0}
+  m_AttachTransform: {fileID: 3856406799651127792}
   m_SecondaryAttachTransform: {fileID: 0}
   m_UseDynamicAttach: 0
   m_MatchAttachPosition: 1
@@ -575,7 +607,7 @@ MonoBehaviour:
   m_SmoothScale: 0
   m_SmoothScaleAmount: 8
   m_TightenScale: 0.1
-  m_ThrowOnDetach: 1
+  m_ThrowOnDetach: 0
   m_ThrowSmoothingDuration: 0.25
   m_ThrowSmoothingCurve:
     serializedVersion: 2

--- a/Assets/Blocks/Prefabs/Block (WhileBegin).prefab
+++ b/Assets/Blocks/Prefabs/Block (WhileBegin).prefab
@@ -169,6 +169,37 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cfa0bb0545cb23344a907b689c68e9f2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &2556915193971491807
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4229381753925850230}
+  m_Layer: 0
+  m_Name: AttachPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4229381753925850230
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2556915193971491807}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.5}
+  m_LocalScale: {x: 2, y: 4, z: 2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1389943061981320986}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2708516735268130501
 GameObject:
   m_ObjectHideFlags: 0
@@ -339,7 +370,7 @@ Transform:
   m_GameObject: {fileID: 6713015538121544575}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 1.942, y: 0.303, z: 2}
+  m_LocalPosition: {x: 2, y: 0.5, z: 2}
   m_LocalScale: {x: 0.5, y: 0.25, z: 0.5}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -348,6 +379,7 @@ Transform:
   - {fileID: 8009763825008059073}
   - {fileID: 9075289025122379036}
   - {fileID: 9140502789084385113}
+  - {fileID: 4229381753925850230}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &6176100348886939945
@@ -550,7 +582,7 @@ MonoBehaviour:
   m_OnDeactivate:
     m_PersistentCalls:
       m_Calls: []
-  m_AttachTransform: {fileID: 0}
+  m_AttachTransform: {fileID: 4229381753925850230}
   m_SecondaryAttachTransform: {fileID: 0}
   m_UseDynamicAttach: 0
   m_MatchAttachPosition: 1
@@ -575,7 +607,7 @@ MonoBehaviour:
   m_SmoothScale: 0
   m_SmoothScaleAmount: 8
   m_TightenScale: 0.1
-  m_ThrowOnDetach: 1
+  m_ThrowOnDetach: 0
   m_ThrowSmoothingDuration: 0.25
   m_ThrowSmoothingCurve:
     serializedVersion: 2

--- a/Assets/Blocks/Prefabs/Block (WhileEnd).prefab
+++ b/Assets/Blocks/Prefabs/Block (WhileEnd).prefab
@@ -169,6 +169,37 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cfa0bb0545cb23344a907b689c68e9f2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1296100267878180909
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 820917081470193162}
+  m_Layer: 0
+  m_Name: AttachPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &820917081470193162
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1296100267878180909}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.5}
+  m_LocalScale: {x: 2, y: 4, z: 2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1389943061981320986}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2708516735268130501
 GameObject:
   m_ObjectHideFlags: 0
@@ -339,7 +370,7 @@ Transform:
   m_GameObject: {fileID: 6713015538121544575}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 1.942, y: 0.303, z: 2}
+  m_LocalPosition: {x: 2, y: 0.5, z: 2}
   m_LocalScale: {x: 0.5, y: 0.25, z: 0.5}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -348,6 +379,7 @@ Transform:
   - {fileID: 8009763825008059073}
   - {fileID: 9075289025122379036}
   - {fileID: 9140502789084385113}
+  - {fileID: 820917081470193162}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &6176100348886939945
@@ -550,7 +582,7 @@ MonoBehaviour:
   m_OnDeactivate:
     m_PersistentCalls:
       m_Calls: []
-  m_AttachTransform: {fileID: 0}
+  m_AttachTransform: {fileID: 820917081470193162}
   m_SecondaryAttachTransform: {fileID: 0}
   m_UseDynamicAttach: 0
   m_MatchAttachPosition: 1
@@ -575,7 +607,7 @@ MonoBehaviour:
   m_SmoothScale: 0
   m_SmoothScaleAmount: 8
   m_TightenScale: 0.1
-  m_ThrowOnDetach: 1
+  m_ThrowOnDetach: 0
   m_ThrowSmoothingDuration: 0.25
   m_ThrowSmoothingCurve:
     serializedVersion: 2

--- a/Assets/Blocks/Prefabs/Wire.prefab
+++ b/Assets/Blocks/Prefabs/Wire.prefab
@@ -1,0 +1,354 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1752949246329499892
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4348098812503421892}
+  - component: {fileID: 3068684081732708319}
+  - component: {fileID: 7720277368006361007}
+  - component: {fileID: 6643761462636693919}
+  - component: {fileID: 6110975470368991777}
+  - component: {fileID: 6413897309508282384}
+  m_Layer: 0
+  m_Name: Wire
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4348098812503421892
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1752949246329499892}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.05, y: 0.5, z: 0.05}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3242917715899884196}
+  - {fileID: 4099657533912805620}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &3068684081732708319
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1752949246329499892}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &7720277368006361007
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1752949246329499892}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: acceb75f46a3a67b4b268ad4459ac45c, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!136 &6643761462636693919
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1752949246329499892}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5000001
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
+--- !u!54 &6110975470368991777
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1752949246329499892}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!114 &6413897309508282384
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1752949246329499892}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ad34abafad169848a38072baa96cdb2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_InteractionManager: {fileID: 0}
+  m_Colliders: []
+  m_InteractionLayerMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_InteractionLayers:
+    m_Bits: 1
+  m_DistanceCalculationMode: 1
+  m_SelectMode: 0
+  m_FocusMode: 1
+  m_CustomReticle: {fileID: 0}
+  m_AllowGazeInteraction: 0
+  m_AllowGazeSelect: 0
+  m_OverrideGazeTimeToSelect: 0
+  m_GazeTimeToSelect: 0.5
+  m_OverrideTimeToAutoDeselectGaze: 0
+  m_TimeToAutoDeselectGaze: 3
+  m_AllowGazeAssistance: 0
+  m_FirstHoverEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_LastHoverExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_HoverEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_HoverExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FirstSelectEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_LastSelectExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_SelectEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_SelectExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FirstFocusEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_LastFocusExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FocusEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FocusExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Activated:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Deactivated:
+    m_PersistentCalls:
+      m_Calls: []
+  m_StartingHoverFilters: []
+  m_StartingSelectFilters: []
+  m_StartingInteractionStrengthFilters: []
+  m_OnFirstHoverEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnLastHoverExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnHoverEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnHoverExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnSelectEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnSelectExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnSelectCanceled:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnActivate:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnDeactivate:
+    m_PersistentCalls:
+      m_Calls: []
+  m_AttachTransform: {fileID: 0}
+  m_SecondaryAttachTransform: {fileID: 0}
+  m_UseDynamicAttach: 0
+  m_MatchAttachPosition: 1
+  m_MatchAttachRotation: 1
+  m_SnapToColliderVolume: 1
+  m_ReinitializeDynamicAttachEverySingleGrab: 1
+  m_AttachEaseInTime: 0.15
+  m_MovementType: 2
+  m_VelocityDamping: 1
+  m_VelocityScale: 1
+  m_AngularVelocityDamping: 1
+  m_AngularVelocityScale: 1
+  m_TrackPosition: 1
+  m_SmoothPosition: 0
+  m_SmoothPositionAmount: 8
+  m_TightenPosition: 0.1
+  m_TrackRotation: 1
+  m_SmoothRotation: 0
+  m_SmoothRotationAmount: 8
+  m_TightenRotation: 0.1
+  m_TrackScale: 1
+  m_SmoothScale: 0
+  m_SmoothScaleAmount: 8
+  m_TightenScale: 0.1
+  m_ThrowOnDetach: 0
+  m_ThrowSmoothingDuration: 0.25
+  m_ThrowSmoothingCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 1
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  m_ThrowVelocityScale: 1.5
+  m_ThrowAngularVelocityScale: 1
+  m_ForceGravityOnDetach: 0
+  m_RetainTransformParent: 1
+  m_AttachPointCompatibilityMode: 0
+  m_StartingSingleGrabTransformers: []
+  m_StartingMultipleGrabTransformers: []
+  m_AddDefaultGrabTransformers: 1
+--- !u!1 &2898419179597665700
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3242917715899884196}
+  m_Layer: 0
+  m_Name: SnapPointTop
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3242917715899884196
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2898419179597665700}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -1, z: 0}
+  m_LocalScale: {x: 10, y: 0.5, z: 10}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4348098812503421892}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &9139149025738643925
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4099657533912805620}
+  m_Layer: 0
+  m_Name: SnapPointBottom
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4099657533912805620
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9139149025738643925}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: 0}
+  m_LocalScale: {x: 10, y: 0.5, z: 10}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4348098812503421892}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Blocks/Prefabs/Wire.prefab.meta
+++ b/Assets/Blocks/Prefabs/Wire.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ce09021ed91169e43b62c806dddc7707
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Blocks/Scripts/BlockSnapping.cs
+++ b/Assets/Blocks/Scripts/BlockSnapping.cs
@@ -52,19 +52,29 @@ public class BlockSnapping : MonoBehaviour
         if (sender.gameObject.name == "SnapTriggerTop" && other.gameObject.name == "SnapTriggerBottom" && !hasSnapped)
         {
             // Get SnappedForwarding from other.SnapTriggerBottom
-            SnappedForwarding snappedForwarding = other.gameObject.GetComponent<SnappedForwarding>();
+            SnappedForwarding otherSnappedForwarding = other.gameObject.GetComponent<SnappedForwarding>();
+            SnappedForwarding thisSnappedForwarding = GetComponentInChildren<SnappedForwarding>();
 
             // Check if the bottom trigger is already snapped
-            if (snappedForwarding != null && snappedForwarding.CanSnap())
+            if (otherSnappedForwarding != null && otherSnappedForwarding.CanSnap())
             {
-                Debug.Log($"{sender.name} collided with {other.name}. Attempting to snap.");
-                SnapToBlock(this.gameObject, other.transform.parent.gameObject);
+                GameObject parentObject = other.transform.parent?.gameObject;
+                if (parentObject != null)
+                {
+                    Debug.Log($"{sender.name} collided with {other.name}. Attempting to snap.");
+                    SnapToBlock(this.gameObject, other.transform.parent.gameObject);
 
-                hasSnapped = true;
-                snappedForwarding.ConnectedBlock = this.gameObject;
+                    hasSnapped = true;
+                    otherSnappedForwarding.ConnectedBlock = this.gameObject;
+                    thisSnappedForwarding.IsRootBlock = false;
 
-                // Set other block to snapped
-                snappedForwarding.SetSnapped(true);
+                    // Set other block to snapped
+                    otherSnappedForwarding.SetSnapped(true);
+                }
+                else
+                {
+                    Debug.LogError("Parent object is null!");
+                }
             }
             else
             {
@@ -72,7 +82,6 @@ public class BlockSnapping : MonoBehaviour
             }
         }
     }
-
 
     private void SnapToBlock(GameObject block1, GameObject block2)
     {
@@ -92,12 +101,21 @@ public class BlockSnapping : MonoBehaviour
         topRb.constraints = RigidbodyConstraints.None;
         bottomRb.constraints = RigidbodyConstraints.None;
 
-        // Reset X and Z rotations for both blocks
-        block1.transform.rotation = Quaternion.Euler(0, block1.transform.rotation.eulerAngles.y, 0);
-        block2.transform.rotation = Quaternion.Euler(0, block1.transform.rotation.eulerAngles.y, 0);
+        // Reset X and Z rotations for both blocks IF blocks are NOT wires
+        if (!block1.name.Contains("Wire"))
+        {
+            block1.transform.rotation = Quaternion.Euler(0, block1.transform.rotation.eulerAngles.y, 0);
+        }
+        if (!block2.name.Contains("Wire"))
+        {
+            block2.transform.rotation = Quaternion.Euler(0, block2.transform.rotation.eulerAngles.y, 0);
+        }
 
-        // Snap bottom block's SnapPointBottom to top block's SnapPointTop
-        block2.transform.position = snapPointTop.position - (snapPointBottom.position - block2.transform.position);
+        // Snap bottom block's SnapPointBottom to top block's SnapPointTop IF blocks are NOT wires
+        if (!block2.name.Contains("Wire"))
+        {
+            block2.transform.position = snapPointTop.position - (snapPointBottom.position - block2.transform.position);
+        }
 
         // Add FixedJoint to lock blocks together
         if (bottomRb != null)
@@ -137,6 +155,13 @@ public class BlockSnapping : MonoBehaviour
         }
 
         StartCoroutine(ResetSnapStatusAfterDelay()); // Wait arbitrary amount of time to prevent block resnapping immediately.
+
+        // Set the IsRootBlock back to true on the grabbed block
+        SnappedForwarding snappedForwarding = gameObject.GetComponentInChildren<SnappedForwarding>();
+        if (snappedForwarding != null)
+        {
+            snappedForwarding.IsRootBlock = true;
+        }
     }
 
     private void ResetSnapStatusOnOtherBlock(GameObject otherBlock)
@@ -177,7 +202,7 @@ public class BlockSnapping : MonoBehaviour
         Debug.Log($"Block released: {gameObject.name}");
 
         Rigidbody rb = GetComponent<Rigidbody>();
-        SnappedForwarding snappedForwarding = GetComponent<SnappedForwarding>();
+        SnappedForwarding snappedForwarding = GetComponentInChildren<SnappedForwarding>();
 
         if (rb == null)
         {
@@ -210,7 +235,7 @@ public class BlockSnapping : MonoBehaviour
             // Do NOT change rb.constraints
         }
         // Case 2: Block IS NOT snapped on top or bottom
-        else if (canSnap == false && hasSnapped == false)
+        else if (canSnap == true && hasSnapped == false)
         {
             Debug.Log($"CASE 2");
             rb.useGravity = true;
@@ -227,6 +252,138 @@ public class BlockSnapping : MonoBehaviour
             rb.constraints = RigidbodyConstraints.FreezePosition | RigidbodyConstraints.FreezeRotation;
         }
 
+        CheckColumnSize();
         queueReading?.ReadQueue();
     }
+
+    private GameObject GetNthBlock(GameObject startingBlock, int n) // Function created to find blocks for CheckColumnSize()
+    {
+        int count = 1;
+        GameObject current = startingBlock;
+        while (current != null && count < n)
+        {
+            // Get the SnappedForwarding component on the current block
+            SnappedForwarding sf = current.GetComponentInChildren<SnappedForwarding>();
+            if (sf != null && sf.ConnectedBlock != null)
+            {
+                current = sf.ConnectedBlock;
+                count++;
+            }
+            else
+            {
+                break;
+            }
+        }
+        return (count == n) ? current : null;
+    }
+
+    private void CheckColumnSize()
+    {
+        // Get the SnappedForwarding component
+        SnappedForwarding thisSnappedForwarding = GetComponentInChildren<SnappedForwarding>();
+        if (thisSnappedForwarding == null)
+        {
+            Debug.LogWarning("SnappedForwarding component not found on this block.");
+            return;
+        }
+
+        GameObject startingBlock = transform.gameObject;
+
+        // Find the root block
+        GameObject rootBlock = thisSnappedForwarding.FindRootBlock(startingBlock);
+        if (rootBlock == null)
+        {
+            Debug.LogWarning("Root block not found.");
+            return;
+        }
+
+        // Count the number of blocks attached to the root block (including the root itself)
+        int columnCount = thisSnappedForwarding.CountBlocks(rootBlock);
+        Debug.Log($"Column count: {columnCount}");
+
+        // If the column count exceeds 5, reposition the 6th block and then create a new joint between block 5 and block 6.
+        if (columnCount > 5)
+        {
+            // Retrieve the 6th block in the chain
+            GameObject sixthBlock = GetNthBlock(rootBlock, 6);
+            if (sixthBlock != null)
+            {
+                // Break the joint connection on the sixth block if it exists to allow repositioning
+                FixedJoint joint = sixthBlock.GetComponent<FixedJoint>();
+                if (joint != null)
+                {
+                    Destroy(joint);
+                    Debug.Log($"FixedJoint on {sixthBlock.name} destroyed.");
+                }
+
+                // Reposition the 6th block: set its position to rootBlock's position plus 1 unit along the X axis. (Will adjust to make it dynamic.)
+                Vector3 newPosition = rootBlock.transform.position + new Vector3(1f, 0f, 0f);
+                sixthBlock.transform.position = newPosition;
+                Debug.Log($"Sixth block {sixthBlock.name} repositioned to new column at {newPosition}");
+
+                Rigidbody rbSixth = sixthBlock.GetComponent<Rigidbody>();
+                if (rbSixth != null)
+                {
+                    rbSixth.useGravity = false;
+                    rbSixth.velocity = Vector3.zero;
+                    rbSixth.angularVelocity = Vector3.zero;
+                    rbSixth.constraints = RigidbodyConstraints.FreezePosition | RigidbodyConstraints.FreezeRotation;
+                }
+                else
+                {
+                    Debug.LogWarning($"Rigidbody not found on {sixthBlock.name}");
+                }
+
+                // Mark the 6th block as a new root block.
+                SnappedForwarding sixthSF = sixthBlock.GetComponentInChildren<SnappedForwarding>();
+                if (sixthSF != null)
+                {
+                    sixthSF.IsRootBlock = true;
+                }
+
+                //Create a new joint between the 5th and 6th blocks
+                GameObject fifthBlock = GetNthBlock(rootBlock, 5);
+                if (fifthBlock != null)
+                {
+                    Rigidbody rbFifth = fifthBlock.GetComponent<Rigidbody>();
+                    if (rbFifth != null && rbSixth != null)
+                    {
+                        FixedJoint newJoint = sixthBlock.AddComponent<FixedJoint>();
+                        newJoint.connectedBody = rbFifth;
+                        newJoint.breakForce = Mathf.Infinity;
+                        newJoint.breakTorque = Mathf.Infinity;
+                        Debug.Log($"New joint created between {sixthBlock.name} and {fifthBlock.name}.");
+                    }
+                    else
+                    {
+                        Debug.LogWarning("Could not find Rigidbody on the 5th or 6th block for joint creation.");
+                    }
+                }
+                else
+                {
+                    Debug.LogWarning("Could not locate the fifth block in the column.");
+                }
+            }
+            else
+            {
+                Debug.LogWarning("Could not locate the sixth block in the column.");
+            }
+        }
+    }
+
+
+    /*public GameObject SpawnWire(Vector3 spawnPosition, Quaternion spawnRotation)
+    {
+        // Load the wire prefab from the blocks folder
+        GameObject wirePrefab = Blocks.Load<GameObject>("Prefabs/Wire");
+
+        if (wirePrefab == null)
+        {
+            Debug.LogError("Wire prefab not found! Make sure it's located in Assets/Blocks/Prefabs as 'Wire'.");
+            return null;
+        }
+
+        GameObject wireInstance = Instantiate(wirePrefab, spawnPosition, spawnRotation);
+        return wireInstance;
+    }*/
 }

--- a/Assets/Blocks/Scripts/SnappedForwarding.cs
+++ b/Assets/Blocks/Scripts/SnappedForwarding.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 
 public class SnappedForwarding : MonoBehaviour
 {
+    public bool IsRootBlock { get; set; } = true;
     public bool IsSnapped { get; private set; } = false;  // Flag to prevent further snapping
     public GameObject ConnectedBlock { get; set; }
 
@@ -15,5 +16,106 @@ public class SnappedForwarding : MonoBehaviour
     public void SetSnapped(bool snapped)
     {
         IsSnapped = snapped;
+    }
+
+    // Method to count blocks attached to root
+    public int CountBlocks(GameObject startingBlock)
+    {
+        int blockCount = 0;
+        if (startingBlock != null)
+        {
+            ReadBlocks(startingBlock, ref blockCount);
+        }
+        else
+        {
+            Debug.LogError("Starting block is null!");
+        }
+        return blockCount;
+    }
+
+    private void ReadBlocks(GameObject currentBlock, ref int blockCount)
+    {
+        // Skip wire blocks by checking their name
+        if (currentBlock == null || currentBlock.name.Contains("Wire"))
+        {
+            return;
+        }
+
+        // Count the current block
+        blockCount++;
+
+        // Check if there is a connected block and read the next one
+        SnappedForwarding snappedForwarding = currentBlock.GetComponentInChildren<SnappedForwarding>();
+        if (snappedForwarding != null && snappedForwarding.ConnectedBlock != null)
+        {
+            GameObject connectedBlock = snappedForwarding.ConnectedBlock;
+            if (connectedBlock != null)
+            {
+                ReadBlocks(connectedBlock, ref blockCount);
+            }
+            else
+            {
+                Debug.LogWarning($"ConnectedBlock is null for {currentBlock.name}. Stopping traversal.");
+            }
+        }
+        else
+        {
+            Debug.LogWarning($"No connected block found for {currentBlock.name}. Stopping traversal.");
+        }
+    }
+
+    public GameObject FindRootBlock(GameObject startingBlock)
+    {
+        // Null check for starting block
+        if (startingBlock == null)
+        {
+            Debug.LogError("Starting block is null!");
+            return null;
+        }
+
+        // Check if the starting block is the root block
+        SnappedForwarding startingSnappedForwarding = startingBlock.GetComponentInChildren<SnappedForwarding>();
+        if (startingSnappedForwarding != null && startingSnappedForwarding.IsRootBlock)
+        {
+            Debug.Log($"Starting block {startingBlock.name} is the root block.");
+            return startingBlock;
+        }
+
+        GameObject currentBlock = startingBlock;
+
+        // Loop until we find the root block
+        while (currentBlock != null)
+        {
+            FixedJoint joint = currentBlock.GetComponent<FixedJoint>();
+
+            if (joint != null)
+            {
+                Rigidbody connectedBody = joint.connectedBody;
+                if (connectedBody != null)
+                {
+                    currentBlock = connectedBody.gameObject;  // Move to the connected block
+                }
+                else
+                {
+                    Debug.Log($"No connected body found for {currentBlock.name}. Stopping traversal.");
+                    break;
+                }
+            }
+            else
+            {
+                Debug.Log($"No FixedJoint found for {currentBlock.name}. Stopping traversal.");
+                break;
+            }
+
+            SnappedForwarding snappedForwarding = currentBlock.GetComponentInChildren<SnappedForwarding>();
+            if (snappedForwarding != null && snappedForwarding.IsRootBlock)
+            {
+                Debug.Log($"Root block found: {currentBlock.name}");
+                return currentBlock;
+            }
+        }
+
+        Debug.Log($"No root block found starting from {startingBlock.name}");
+        return null;
     }
 }


### PR DESCRIPTION
### Incorporated column spawning, when block queue (or any other stack of blocks) reaches an excess of 5 blocks, a new column will spawn. Functions as if they are attached normally, with an invisible joint (for now). Also adds some updates to the block physics, scripts, and prefabs. Details listed below:

Block Physics/Scripts:

Added an AttachPoint game object to each Block Prefab to act as an attach transform point, preventing clipping through the XR camera.
Made each Block Prefab's starting position uniform (may be unnecessary but could save a headache in the future if it effects spawn position).
Updated block physics script to force blocks to float after they have been picked up for the first time using RigidbodyConstraints.
Made unsnapped Blocks (except Queue Block) react to physics when snapped to no other blocks.
KNOWN BUG: If you grab a block and it snaps to queue block during the block grab, it will functionally act as if it's snapped but will not unsnap if grabbed.
KNOWN BUG: If you attach the bottom block to top block, top block rotation will match the bottom block's. Should be reset to 0 following release.
KNOWN BUG: If you unsnap the bottom block from the top block and release very quickly, bottom block will float in the air as if it's snapped.
KNOWN BUG: If you snap while holding the top block, a small gap will exist sometimes.
TODO: Update the other block on OnRelease function (For example, top block should react to gravity when you unsnap the final block from it).

Column spawning:

Added IsRootBlock Boolean and FindRootBlock function which are used to define block as top block in a column.
Added ReadBlocks function to recursively count blocks attached to Root in order to determine whether a wire should be spawned.
Added CheckColumnSize function which creates a new column when column size exceeds 5 Blocks.
KNOWN BUG: Rotation does not properly match the root block on new column creation.
UNTESTED: Adding blocks to where you'll need to add multiple columns at once (i.e., going from 4 to 11 blocks). Limited use case, will work on later.
UNTESTED: Interactions when unsnapping 5th block (etc.) and moving spawned columns alongside it (not an intended function, but something I need to account for).
TODO: Reposition new column dynamically based on root block's rotation, rather than +1 along the x-axis.
TODO: Reorganize columns dynamically depending on size of split stack (For example, splitting the 5-8th blocks from a stack of 8 should create 2 columns of 4).
TODO: Finish SpawnWire function to spawn a wire to connect two created columns when column exceeds 5 Blocks.