### PR TITLE
added simple recursion detection and avoidance

### DIFF
--- a/Assets/Blocks/Prefabs/Block (Function).prefab
+++ b/Assets/Blocks/Prefabs/Block (Function).prefab
@@ -481,10 +481,34 @@ MonoBehaviour:
   m_AllowGazeAssistance: 0
   m_FirstHoverEntered:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 6362424727914982184}
+        m_TargetAssemblyTypeName: FunctionBlock, Assembly-CSharp
+        m_MethodName: OnHoverEntered
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   m_LastHoverExited:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 6362424727914982184}
+        m_TargetAssemblyTypeName: FunctionBlock, Assembly-CSharp
+        m_MethodName: OnHoverExited
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   m_HoverEntered:
     m_PersistentCalls:
       m_Calls: []
@@ -639,6 +663,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: aa675a2c6a3d3aaa5a1538a205afecee, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  primaryButton: {fileID: -3059995133750637719, guid: c348712bda248c246b8c49b3db54643f, type: 3}
+  functionCallPrefab: {fileID: 6713015538121544575, guid: 6624236ae1e177e2cb847d4bf721f9ca, type: 3}
+  spawnOffset: {x: 0, y: 1, z: 1}
+  FunctionID: 0
 --- !u!1 &8338628556024756916
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Blocks/Scripts/FunctionBlock.cs
+++ b/Assets/Blocks/Scripts/FunctionBlock.cs
@@ -19,6 +19,7 @@ public class FunctionBlock : MonoBehaviour
     {
       primaryButton.action.started += onPrimaryButton;
       queueReading = gameObject.GetComponent<QueueReading>();
+      FunctionID = gameObject.GetInstanceID();
     }
 
     void onActivation(){
@@ -27,12 +28,12 @@ public class FunctionBlock : MonoBehaviour
 
     public void OnHoverEntered(){
       isHovered = true;
-      Debug.Log("FunctionDefinintionBlock: Hovered");
+      //Debug.Log("FunctionDefinintionBlock: Hovered");
     }
 
     public void OnHoverExited(){
       isHovered = false;
-      Debug.Log("FunctionDefinintionBlock: Not Hovered");
+      //Debug.Log("FunctionDefinintionBlock: Not Hovered");
     }
 
     void onPrimaryButton(InputAction.CallbackContext context){

--- a/Assets/Blocks/Scripts/FunctionBlock.cs
+++ b/Assets/Blocks/Scripts/FunctionBlock.cs
@@ -10,7 +10,7 @@ public class FunctionBlock : MonoBehaviour
     public InputActionReference primaryButton;
     public GameObject functionCallPrefab;
     public Vector3 spawnOffset;
-    public int idNumber;
+    public int FunctionID;
 
     private QueueReading queueReading;
     private bool isHovered = false;
@@ -49,7 +49,8 @@ public class FunctionBlock : MonoBehaviour
       FunctionCallBlock fcb = newFunctionCall.AddComponent(typeof(FunctionCallBlock)) as FunctionCallBlock;
       fcb.functionDefinition = gameObject;
       var FCLabel = newFunctionCall.GetComponent<Transform>().Find("BlockLabel/LabelText").gameObject.GetComponent<TextMeshProUGUI>();
-      FCLabel.text = "Call " + idNumber.ToString();
+      FCLabel.text = "Call " + FunctionID.ToString();
+      fcb.GetComponent<FunctionCallBlock>().FunctionID = FunctionID;
     }
 }
 

--- a/Assets/Blocks/Scripts/FunctionCallBlock.cs
+++ b/Assets/Blocks/Scripts/FunctionCallBlock.cs
@@ -8,6 +8,11 @@ public class FunctionCallBlock : MonoBehaviour
     public GameObject functionDefinition;
     public int FunctionID;
 
+    void Start(){
+        //FunctionID = functionDefinition.GetComponent<FunctionBlock>().FunctionID;
+        FunctionID = functionDefinition.GetInstanceID();
+    }
+
     public Queue<UnityEvent> getFunction(){
         QueueReading functionDefinitionQueueReading = functionDefinition.GetComponent<QueueReading>();
         functionDefinitionQueueReading.ReadQueue();

--- a/Assets/Blocks/Scripts/FunctionCallBlock.cs
+++ b/Assets/Blocks/Scripts/FunctionCallBlock.cs
@@ -6,6 +6,7 @@ using UnityEngine.Events;
 public class FunctionCallBlock : MonoBehaviour
 {
     public GameObject functionDefinition;
+    public int FunctionID;
 
     public Queue<UnityEvent> getFunction(){
         QueueReading functionDefinitionQueueReading = functionDefinition.GetComponent<QueueReading>();

--- a/Assets/Blocks/Scripts/NewFunctionButton.cs
+++ b/Assets/Blocks/Scripts/NewFunctionButton.cs
@@ -44,7 +44,7 @@ public class NewFunctionButton : MonoBehaviour
         FDLabel.text = "Function " + nextFunctionNumber.ToString();
         FCLabel.text = "Call " + (string)nextFunctionNumber.ToString();
 
-        newFunctionDefinitionInstance.GetComponent<FunctionBlock>().idNumber = nextFunctionNumber;
+        newFunctionDefinitionInstance.GetComponent<FunctionBlock>().FunctionID = nextFunctionNumber;
 
         nextFunctionNumber++;
 

--- a/Assets/Blocks/Scripts/NewFunctionButton.cs
+++ b/Assets/Blocks/Scripts/NewFunctionButton.cs
@@ -9,7 +9,6 @@ public class NewFunctionButton : MonoBehaviour
     public Vector3 functionCallBlockOffset = Vector3.zero;
     public Vector3 blockRotation = new Vector3(0, 180, 0);
     //public Vector3 blockScale = new Vector3(2.5f, 2.25f, 2.5f);
-    public int nextFunctionNumber = 0;
 
     public GameObject functionDefinitionBlockPrefab;
     public GameObject functionCallBlockPrefab;
@@ -23,16 +22,14 @@ public class NewFunctionButton : MonoBehaviour
         var transform = GetComponent<Transform>();
         var blockEntity = GameObject.Find("MoveableEntities/BlockEntity").GetComponent<Transform>();
 
-        functionDefinitionBlockOffset += transform.position;
-        functionCallBlockOffset += transform.position;
+        GameObject newFunctionDefinitionInstance = Instantiate(functionDefinitionBlockPrefab, functionDefinitionBlockOffset + transform.position, Quaternion.Euler(blockRotation), blockEntity);
+        GameObject newFunctionCallInstance = Instantiate(functionCallBlockPrefab, functionCallBlockOffset + transform.position, Quaternion.Euler(blockRotation), blockEntity);
 
-        GameObject newFunctionDefinitionInstance = Instantiate(functionDefinitionBlockPrefab, functionDefinitionBlockOffset, Quaternion.Euler(blockRotation), blockEntity);
-        GameObject newFunctionCallInstance = Instantiate(functionCallBlockPrefab, functionCallBlockOffset, Quaternion.Euler(blockRotation), blockEntity);
+        int FDInstanceID = newFunctionDefinitionInstance.GetInstanceID();
 
         newFunctionDefinitionInstance.name = "Block (Function)";
         newFunctionCallInstance.name = "Block (FunctionCall)";
 
-        newFunctionDefinitionInstance.AddComponent(typeof(FunctionBlock));
         newFunctionDefinitionInstance.AddComponent(typeof(QueueReading));
         FunctionCallBlock fcb = newFunctionCallInstance.AddComponent(typeof(FunctionCallBlock)) as FunctionCallBlock;
         fcb.functionDefinition = newFunctionDefinitionInstance;
@@ -41,15 +38,10 @@ public class NewFunctionButton : MonoBehaviour
         var FCLabel = newFunctionCallInstance.GetComponent<Transform>().Find("BlockLabel/LabelText").gameObject.GetComponent<TextMeshProUGUI>();
         var FDLabel = newFunctionDefinitionInstance.GetComponent<Transform>().Find("BlockLabel/LabelText").gameObject.GetComponent<TextMeshProUGUI>();
 
-        FDLabel.text = "Function " + nextFunctionNumber.ToString();
-        FCLabel.text = "Call " + (string)nextFunctionNumber.ToString();
+        FDLabel.text = "Function " + FDInstanceID.ToString();
+        FCLabel.text = "Call " + FDInstanceID.ToString();
 
-        newFunctionDefinitionInstance.GetComponent<FunctionBlock>().FunctionID = nextFunctionNumber;
-
-        nextFunctionNumber++;
-
-        //newFunctionCallInstance.transform.localScale = blockScale;
-        //newFunctionDefinitionInstance.transform.localScale = blockScale;
+        newFunctionDefinitionInstance.GetComponent<FunctionBlock>().FunctionID = FDInstanceID;
     }
 
     public void SetGlowEffect(bool isGlow){

--- a/Assets/Blocks/Scripts/QueueReading.cs
+++ b/Assets/Blocks/Scripts/QueueReading.cs
@@ -7,9 +7,14 @@ public class QueueReading : MonoBehaviour
     // Queue to hold the block types (FIFO order)
     private Queue<string> blockQueue = new Queue<string>();
     private Queue<UnityEvent> eventQueue = new Queue<UnityEvent>();
+    private bool amFunction = false;
     public void ReadQueue()
     {
         Debug.Log("Starting Queue Reading...");
+
+        if(gameObject.GetComponent<FunctionBlock>()){
+            amFunction = true;
+        }
 
         // Clear previous readings
         blockQueue.Clear();
@@ -53,6 +58,14 @@ public class QueueReading : MonoBehaviour
 
         // if block is function, get function contents
         if(blockType == "Block (FunctionCall)"){
+            if(amFunction){
+                int connectedID = connectedBlock.GetComponent<FunctionCallBlock>().FunctionID;
+                int thisID = gameObject.GetComponent<FunctionBlock>().FunctionID;
+                if (connectedID == thisID){
+                    Debug.Log("Block (Function): QueueReading: Recursion Detected! Aborting!");
+                    return;
+                }
+            }
             Queue<UnityEvent> functionQueue = connectedBlock.GetComponent<FunctionCallBlock>().getFunction();
             while(functionQueue.Count > 0){
                 eventQueue.Enqueue(functionQueue.Dequeue());

--- a/Assets/Blocks/Scripts/QueueReading.cs
+++ b/Assets/Blocks/Scripts/QueueReading.cs
@@ -5,16 +5,15 @@ using UnityEngine.Events;
 public class QueueReading : MonoBehaviour
 {
     // Queue to hold the block types (FIFO order)
-    private Queue<string> blockQueue = new Queue<string>();
-    private Queue<UnityEvent> eventQueue = new Queue<UnityEvent>();
+    private readonly Queue<string> blockQueue = new Queue<string>();
+    private readonly Queue<UnityEvent> eventQueue = new Queue<UnityEvent>();
     private bool amFunction = false;
+    private FunctionBlock functionBlock;
     public void ReadQueue()
     {
         Debug.Log("Starting Queue Reading...");
 
-        if(gameObject.GetComponent<FunctionBlock>()){
-            amFunction = true;
-        }
+        functionBlock = gameObject.GetComponent<FunctionBlock>();
 
         // Clear previous readings
         blockQueue.Clear();
@@ -58,7 +57,7 @@ public class QueueReading : MonoBehaviour
 
         // if block is function, get function contents
         if(blockType == "Block (FunctionCall)"){
-            if(amFunction){
+            if(functionBlock){
                 int connectedID = connectedBlock.GetComponent<FunctionCallBlock>().FunctionID;
                 int thisID = gameObject.GetComponent<FunctionBlock>().FunctionID;
                 if (connectedID == thisID){

--- a/Assets/Blocks/Scripts/QueueReading.cs
+++ b/Assets/Blocks/Scripts/QueueReading.cs
@@ -7,7 +7,6 @@ public class QueueReading : MonoBehaviour
     // Queue to hold the block types (FIFO order)
     private readonly Queue<string> blockQueue = new Queue<string>();
     private readonly Queue<UnityEvent> eventQueue = new Queue<UnityEvent>();
-    private bool amFunction = false;
     private FunctionBlock functionBlock;
     public void ReadQueue()
     {

--- a/Assets/Blocks/Scripts/QueueReading.cs
+++ b/Assets/Blocks/Scripts/QueueReading.cs
@@ -58,7 +58,7 @@ public class QueueReading : MonoBehaviour
         if(blockType == "Block (FunctionCall)"){
             if(functionBlock){
                 int connectedID = connectedBlock.GetComponent<FunctionCallBlock>().FunctionID;
-                int thisID = gameObject.GetComponent<FunctionBlock>().FunctionID;
+                int thisID = functionBlock.FunctionID;
                 if (connectedID == thisID){
                     Debug.Log("Block (Function): QueueReading: Recursion Detected! Aborting!");
                     return;

--- a/Assets/Map/Turtle/TurtleMovement.cs
+++ b/Assets/Map/Turtle/TurtleMovement.cs
@@ -277,6 +277,8 @@ public class TurtleMovement : MonoBehaviour
 
         SetIsWalking(false);
         queue.Clear();
+
+        // NullReferenceException!
         tween.reset();
 
         rb.velocity = Vector3.zero;
@@ -381,9 +383,12 @@ public class TurtleMovement : MonoBehaviour
 
     private void Fail(Action failMovement = null)
     {
+
         rb.constraints = RigidbodyConstraints.None;
         turtleCollider.material.bounciness = failBounciness;
         queue.Clear();
+
+        //NullReferenceException!
         tween.reset();
 
         failMovement?.Invoke();

--- a/Assets/Scenes/Basic Level View.unity
+++ b/Assets/Scenes/Basic Level View.unity
@@ -3798,11 +3798,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1389943061981320986, guid: 6624236ae1e177e2cb847d4bf721f9ca, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.149
+      value: 0.28
       objectReference: {fileID: 0}
     - target: {fileID: 1389943061981320986, guid: 6624236ae1e177e2cb847d4bf721f9ca, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -3.5246835
+      value: -3.34
       objectReference: {fileID: 0}
     - target: {fileID: 1389943061981320986, guid: 6624236ae1e177e2cb847d4bf721f9ca, type: 3}
       propertyPath: m_LocalRotation.w
@@ -3867,6 +3867,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   functionDefinition: {fileID: 1811471421}
+  FunctionID: 0
 --- !u!1 &530347939
 GameObject:
   m_ObjectHideFlags: 0
@@ -5151,12 +5152,12 @@ MonoBehaviour:
   m_margin: {x: -0.03583335, y: -28.862024, z: -9.593889, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
-  _SortingLayer: 0
-  _SortingLayerID: 0
-  _SortingOrder: 0
   m_hasFontAssetChanged: 0
   m_renderer: {fileID: 740480789}
   m_maskType: 0
+  _SortingLayer: 0
+  _SortingLayerID: 0
+  _SortingOrder: 0
 --- !u!23 &740480789
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -7554,7 +7555,6 @@ MonoBehaviour:
   functionDefinitionBlockOffset: {x: -1, y: 0, z: 0}
   functionCallBlockOffset: {x: -2, y: 0, z: 0}
   blockRotation: {x: 0, y: 180, z: 0}
-  nextFunctionNumber: 0
   functionDefinitionBlockPrefab: {fileID: 6713015538121544575, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
   functionCallBlockPrefab: {fileID: 6713015538121544575, guid: 6624236ae1e177e2cb847d4bf721f9ca, type: 3}
 --- !u!114 &1070190952
@@ -13770,115 +13770,39 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1389943061981320986, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
       propertyPath: m_LocalRotation.w
-      value: -0.0125083765
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1389943061981320986, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.008284492
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1389943061981320986, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.9998346
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1389943061981320986, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.010279678
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1389943061981320986, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 1.166
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1389943061981320986, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: -901.443
+      value: 180
       objectReference: {fileID: 0}
     - target: {fileID: 1389943061981320986, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: -0.964
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6362424727914982184, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
       propertyPath: idNumber
       value: -1
       objectReference: {fileID: 0}
-    - target: {fileID: 6362424727914982184, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
-      propertyPath: primaryButton
-      value: 
-      objectReference: {fileID: -3059995133750637719, guid: c348712bda248c246b8c49b3db54643f, type: 3}
-    - target: {fileID: 6362424727914982184, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
-      propertyPath: spawnOffset.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6362424727914982184, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
-      propertyPath: spawnOffset.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6362424727914982184, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
-      propertyPath: spawnOffset.z
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6362424727914982184, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
-      propertyPath: functionCallPrefab
-      value: 
-      objectReference: {fileID: 6713015538121544575, guid: 6624236ae1e177e2cb847d4bf721f9ca, type: 3}
     - target: {fileID: 6713015538121544575, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
       propertyPath: m_Name
       value: Block (Function)
-      objectReference: {fileID: 0}
-    - target: {fileID: 8298196277154468960, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
-      propertyPath: m_LastHoverExited.m_PersistentCalls.m_Calls.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8298196277154468960, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
-      propertyPath: m_FirstHoverEntered.m_PersistentCalls.m_Calls.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8298196277154468960, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
-      propertyPath: m_LastHoverExited.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8298196277154468960, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
-      propertyPath: m_FirstHoverEntered.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8298196277154468960, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
-      propertyPath: m_LastHoverExited.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 1811471424}
-    - target: {fileID: 8298196277154468960, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
-      propertyPath: m_FirstHoverEntered.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 1811471424}
-    - target: {fileID: 8298196277154468960, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
-      propertyPath: m_LastHoverExited.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8298196277154468960, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
-      propertyPath: m_LastHoverExited.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: OnHoverExited
-      objectReference: {fileID: 0}
-    - target: {fileID: 8298196277154468960, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
-      propertyPath: m_FirstHoverEntered.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8298196277154468960, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
-      propertyPath: m_FirstHoverEntered.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: OnHoverEntered
-      objectReference: {fileID: 0}
-    - target: {fileID: 8298196277154468960, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
-      propertyPath: m_LastHoverExited.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
-      value: FunctionBlock, Assembly-CSharp
-      objectReference: {fileID: 0}
-    - target: {fileID: 8298196277154468960, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
-      propertyPath: m_FirstHoverEntered.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
-      value: FunctionBlock, Assembly-CSharp
-      objectReference: {fileID: 0}
-    - target: {fileID: 8298196277154468960, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
-      propertyPath: m_LastHoverExited.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
-      objectReference: {fileID: 0}
-    - target: {fileID: 8298196277154468960, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
-      propertyPath: m_FirstHoverEntered.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -13908,17 +13832,6 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4cf55196b48accc4bb66553c47f1fa70, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1811471424 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6362424727914982184, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
-  m_PrefabInstance: {fileID: 1811471420}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1811471421}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: aa675a2c6a3d3aaa5a1538a205afecee, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1814067334


### PR DESCRIPTION
This PR implements a simple logic check in the `QueueReading` class which stops evaluation if a `Block (Function)` detects it's own `Block (FunctionCall)` in its queue.

Currently, this just produces a debug message, and no indication to the user, but like @malcolmcase97 suggested, an ideal response is to trigger the blocks breaking apart from one another.