### PR TITLE
workaround undefined string causing null reference exception

### DIFF
--- a/Assets/LevelData/LevelStatesManager.cs
+++ b/Assets/LevelData/LevelStatesManager.cs
@@ -58,6 +58,11 @@ public class LevelStatesManager: MonoBehaviour
     {
         for (int i = 0; i < numStates; i++)
         {
+            if (metadata[i].prerequisiteLevel == null)
+            {
+                Debug.Log($"metadata[{i}].prerequisiteLevel (string) is null. Replacing with empty string");
+                metadata[i].prerequisiteLevel = "";
+            }
             if (metadata[i].prerequisiteLevel.Trim() == prerequisiteLevelName.Trim())
             {
                 unlockLevel(i);


### PR DESCRIPTION
This took an hour and a half.
Here's what I learned:

- There is nothing wrong with `AssetDatabase`. Everything was loading as it should.
- `metadata[i]` was not null. Instead `metadata[i].prerequisiteLevel` was.
- `metadata[i].prerequisiteLevel` was only null for `Assets/LevelData/MetaData/Level1/Level1MetaData.asset`

I could tell from looking at `Level1MetaData.asset` that you intended this to be an empty string, and it ends up being null instead. I have no idea why this is, or how to fix it, but just detecting the null - and setting an empty string - works.