### PR TITLE
Fixed various physics bugs (see description)

### DIFF
--- a/Assets/Blocks/Prefabs/Block (Condition).prefab
+++ b/Assets/Blocks/Prefabs/Block (Condition).prefab
@@ -581,6 +581,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   hasSnapped: 0
+  snapSound: {fileID: 8300000, guid: f2216e2bc9c691543a81acc17015e4f5, type: 3}
 --- !u!114 &5405742046879034240
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Blocks/Scripts/BlockCount.cs
+++ b/Assets/Blocks/Scripts/BlockCount.cs
@@ -1,19 +1,36 @@
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.UI;
 using TMPro;
 
 public class BlockCount : MonoBehaviour
 {
-    [SerializeField] private QueueReading? queueReading; // Attach object that contains this script
-    [SerializeField] private TextMeshProUGUI? blockCountText; // Attach TMP text in BlockCount prefab
+    [SerializeField] private QueueReading queueReading; // Attach object that contains this script
+    [SerializeField] private TextMeshProUGUI blockCountText; // Attach TMP text in BlockCount prefab
 
     void Start()
     {
         queueReading = GameObject.Find("Block (StartQueue)").GetComponent<QueueReading>();
+
+        if (queueReading != null)
+        {
+            queueReading.OnQueueUpdated += UpdateBlockCount;
+            UpdateBlockCount();
+        }
+        else
+        {
+            Debug.LogWarning("QueueReading component not found!");
+        }
     }
 
-    private void Update()
+    private void OnDestroy()
+    {
+        if (queueReading != null)
+        {
+            queueReading.OnQueueUpdated -= UpdateBlockCount;
+        }
+    }
+
+    private void UpdateBlockCount()
     {
         if (queueReading == null || blockCountText == null)
         {
@@ -21,9 +38,7 @@ public class BlockCount : MonoBehaviour
             return;
         }
 
-        Queue<string> blockQueue = queueReading.GetBlockQueue();
-        int blockCount = blockQueue.Count;
-
+        int blockCount = queueReading.GetBlockQueue().Count;
         blockCountText.text = $"Block Count: {blockCount}";
     }
 }

--- a/Assets/Blocks/Scripts/BlockSnapping.cs
+++ b/Assets/Blocks/Scripts/BlockSnapping.cs
@@ -195,7 +195,12 @@ public class BlockSnapping : MonoBehaviour
             }
 
             Destroy(joint);
-            //UpdatePhysics(otherRb);
+
+            SnappedForwarding sf = otherRb.GetComponentInChildren<SnappedForwarding>();
+            if (sf != null)
+            {
+                sf.UpdatePhysics(otherRb);
+            }
         }
 
         // Start the coroutine and store reference for OnRelease()

--- a/Assets/Blocks/Scripts/BlockSnapping.cs
+++ b/Assets/Blocks/Scripts/BlockSnapping.cs
@@ -12,11 +12,22 @@ public class BlockSnapping : MonoBehaviour
 
     private void Awake()
     {
-        // Automatic detection of QueueReading component
-        queueReading = FindObjectOfType<QueueReading>();
+        // Automatic detection of QueueReading component (Specifically, the StartQueue block's QueueReading component)
+        QueueReading[] queueReadings = FindObjectsOfType<QueueReading>();
+
+        // Iterate through queueReading components to find the StartQueue Block.
+        foreach (var qr in queueReadings)
+        {
+            if (qr.gameObject.name.Contains("StartQueue"))
+            {
+                queueReading = qr;
+                break;
+            }
+        }
+
         if (queueReading == null)
         {
-            Debug.LogWarning("QueueReading component not found in the scene. Ensure there is one active in the hierarchy.");
+            Debug.LogWarning("QueueReading component with a block name containing 'StartQueue' not found in the scene. Ensure there is one active in the hierarchy.");
         }
 
         // Collision Forwarding active

--- a/Assets/Blocks/Scripts/QueueReading.cs
+++ b/Assets/Blocks/Scripts/QueueReading.cs
@@ -5,6 +5,8 @@ using UnityEngine.Events;
 
 public class QueueReading : MonoBehaviour
 {
+    public event Action OnQueueUpdated;
+
     // Queue to hold the block types (FIFO order)
 
     private readonly Queue<string> blockQueue = new();
@@ -46,6 +48,8 @@ public class QueueReading : MonoBehaviour
                 Debug.Log(blockType);
             }
         }
+
+        OnQueueUpdated?.Invoke();
     }
 
     private void ReadBlocks(GameObject currentBlock)

--- a/Assets/Blocks/Scripts/QueueReading.cs
+++ b/Assets/Blocks/Scripts/QueueReading.cs
@@ -5,7 +5,7 @@ using UnityEngine.Events;
 
 public class QueueReading : MonoBehaviour
 {
-    public event Action OnQueueUpdated;
+    public event Action OnQueueUpdated; // To update Block Count
 
     // Queue to hold the block types (FIFO order)
 

--- a/Assets/Blocks/Scripts/SnappedForwarding.cs
+++ b/Assets/Blocks/Scripts/SnappedForwarding.cs
@@ -187,15 +187,28 @@ public class SnappedForwarding : MonoBehaviour
                 // Ignore wires
                 if (!otherRbParent.name.Contains("Wire"))
                 {
+                    // Temporarily disable rotation constraints to allow realignment
+                    rb.constraints &= ~RigidbodyConstraints.FreezeRotationX;
+                    rb.constraints &= ~RigidbodyConstraints.FreezeRotationY;
+                    rb.constraints &= ~RigidbodyConstraints.FreezeRotationZ;
+
                     // Update position to match the X and Z of the parent block
                     Vector3 parentPosition = otherRbParent.transform.position;
                     rb.transform.position = new Vector3(parentPosition.x, rb.transform.position.y, parentPosition.z);
+
                     // Reset rotation to 0
                     rb.transform.rotation = Quaternion.Euler(0, 0, 0);
                     Debug.Log($"Physics Update: Position/Rotation reset");
+
+                    // Re-enable the rotation constraints after alignment
+                    rb.constraints |= RigidbodyConstraints.FreezeRotationX;
+                    rb.constraints |= RigidbodyConstraints.FreezeRotationY;
+                    rb.constraints |= RigidbodyConstraints.FreezeRotationZ;
+
                     break;
                 }
             }
         }
     }
+
 }

--- a/Assets/Blocks/Scripts/SnappedForwarding.cs
+++ b/Assets/Blocks/Scripts/SnappedForwarding.cs
@@ -134,7 +134,7 @@ public class SnappedForwarding : MonoBehaviour
         return null;
     }
 
-    private void UpdatePhysics(Rigidbody rb)
+    public void UpdatePhysics(Rigidbody rb)
     {
         SnappedForwarding snappedForwarding = rb.GetComponentInChildren<SnappedForwarding>();
         BlockSnapping blockSnapping = rb.GetComponent<BlockSnapping>();


### PR DESCRIPTION
Fixed the following bugs:

**1. KNOWN BUG: Block Count does not update as frequently as intended, should update on each block release.**
-Added event to QueueReading.cs and listener in BlockCount.cs.
-Modified BlockSnapping.cs to detect the QueueReading component specifically attached to the StartQueue Block.
**2. KNOWN BUG: UpdatePhysics() does not properly update position/rotation of parent/child.**
-Edited SnappedForwarding.UpdatePhysics() to temporarily disable rotation constraints before applying the rotation reset, then re-enabling them, allowing blocks to properly realign.
**3. KNOWN BUG: Unsnapping bottom block of non-queue block (leaving only 1 block) does not cause the single block to react to gravity.**
-BlockSnapping.cs now invokes SnappedForwarding.UpdatePhysics() onGrab (when blocks are unsnapped).
**4. Added sound effect to Block (Condition) I forgot before.**

Created new bug:

KNOWN BUG: Child blocks will not rotate along with parent block after UpdatePhysics() is invoked.

Will address this at some point. I feel like the new bug doesn't really effect gameplay, so it's low priority. (Also don't understand how to fix it, will do research).