### PR TITLE
fixed block count. included counting blocks in functions

### DIFF
--- a/Assets/Blocks/Scripts/BlockCount.cs
+++ b/Assets/Blocks/Scripts/BlockCount.cs
@@ -4,24 +4,9 @@ using TMPro;
 
 public class BlockCount : MonoBehaviour
 {
-    //[SerializeField] private QueueReading? queueReading; // Attach object that contains this script
-    [SerializeField] private ExecutionDirector executionDirector;
     [SerializeField] private TextMeshProUGUI? blockCountText; // Attach TMP text in BlockCount prefab
-
-    void Start()
+    public void SetBlockCount(int count)
     {
-        //queueReading = GameObject.Find("Block (StartQueue)").GetComponent<QueueReading>();
-        executionDirector = GameObject.Find("/ExecutionDirector").GetComponent<ExecutionDirector>();
-        BlockSnapping.blockSnapEvent.AddListener(UpdateBlockCount);
-    }
-    private void UpdateBlockCount()
-    {
-        if (executionDirector == null || blockCountText == null)
-        {
-            Debug.LogWarning("ExecutionDirector or Text component is not assigned.");
-            return;
-        }
-
-        blockCountText.text = $"Block Count: {executionDirector.GetMainListLength()}";
+        blockCountText.text = $"Block Count: {count}";
     }
 }

--- a/Assets/Scenes/Basic Level View.unity
+++ b/Assets/Scenes/Basic Level View.unity
@@ -4872,6 +4872,7 @@ MonoBehaviour:
   turtleMovement: {fileID: 16984051}
   startBlock: {fileID: 1554614508}
   startButton: {fileID: 1846371468}
+  blockCount: {fileID: 2132869180}
 --- !u!4 &431602179
 Transform:
   m_ObjectHideFlags: 0
@@ -7778,6 +7779,10 @@ PrefabInstance:
       propertyPath: queueReading
       value: 
       objectReference: {fileID: 1866267872}
+    - target: {fileID: 5460322276127385670, guid: 6a0d2a4104e79044ab2718ed367beee0, type: 3}
+      propertyPath: executionDirector
+      value: 
+      objectReference: {fileID: 431602178}
     - target: {fileID: 6173332826153927004, guid: 6a0d2a4104e79044ab2718ed367beee0, type: 3}
       propertyPath: m_LocalPosition.x
       value: -2.42
@@ -25407,6 +25412,17 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 400000, guid: 23f69f763336f67488996af0a5d95f78, type: 3}
   m_PrefabInstance: {fileID: 2124615041}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &2132869180 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5460322276127385670, guid: 6a0d2a4104e79044ab2718ed367beee0, type: 3}
+  m_PrefabInstance: {fileID: 676664286}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3f968caca812c34484d886f133630c8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2143723469
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/ExecutionDirector.cs
+++ b/Assets/Scripts/ExecutionDirector.cs
@@ -22,6 +22,7 @@ public class ExecutionDirector : MonoBehaviour
     public TurtleMovement turtleMovement;
     public GameObject startBlock;
     public GameObject startButton;
+    public BlockCount blockCount;
 
     // maintains a list of the blocks under Block (StartQueue)
     private List<GameObject> mainBlockList = new List<GameObject>();
@@ -38,12 +39,6 @@ public class ExecutionDirector : MonoBehaviour
         turtleMovement.FailEvent.AddListener(FailHandler);
         turtleMovement.SuccessEvent.AddListener(SuccessHandler);
     }
-
-    public int GetMainListLength(){
-        return mainBlockList.Count;
-    }
-
-
     public void StartButtonPressed()
     {
         //blockList = mainBlockList;
@@ -605,6 +600,13 @@ public class ExecutionDirector : MonoBehaviour
     {
         ReadMainBlocks();
         GrabFunctionsInScene();
+
+        int blocksAllQueues = mainBlockList.Count;
+        foreach(var fbl in functionBlockLists)
+        {
+            blocksAllQueues += fbl.Value.Count;
+        }
+        blockCount.SetBlockCount(blocksAllQueues);
     }
 
     void GrabFunctionsInScene(){
@@ -644,6 +646,7 @@ public class ExecutionDirector : MonoBehaviour
         {
             Debug.Log($"ExecutionDirector.ReadMainBlocks: {block.name}");
         }
+
     }
 
     List<GameObject> ReadFunctionBlocks(GameObject functionDefinition)


### PR DESCRIPTION
- Removed `BlockCount`'s reference to `ExecutionDirector`.
- Added reference to `BlockCount` to `ExecutionDirector`.
- Changed `private void BlockCount.UpdateBlockCount()` to `public void BlockCount.SetBlockCount(int)`.
- Added code to `ExecutionDirector.OnSnapEvent()` to total up blocks in main function, and all other functions, and call `BlockCount.SetBlockCount(int)`.