### PR TITLE
fix/production_build

### DIFF
--- a/Assets/LevelData/LevelMetadataScriptableObject.cs
+++ b/Assets/LevelData/LevelMetadataScriptableObject.cs
@@ -3,9 +3,10 @@ using UnityEngine;
 [CreateAssetMenu(fileName = "LevelMetadataScriptableObject", menuName = "ScriptableObjects/LevelMetadataScriptableObject", order = 2)]
 public class LevelMetadataScriptableObject : ScriptableObject
 {
+    public string levelName;
     public int maxStarCount = 3;
     public string prerequisiteLevel;
     public string[] levelTutorialEvents;
-
     public string[] levelHints;
+    public Sprite levelThumbnail;
 }

--- a/Assets/LevelData/LevelStates.cs
+++ b/Assets/LevelData/LevelStates.cs
@@ -5,19 +5,29 @@ using UnityEngine;
 public class LevelState
 {
     private string name;
-    private bool isLockedLevel = true;
-    private int starCount = 0;
+    //private bool isLockedLevel = true;
+    //private int starCount = 0;
+
+    /*
+    * Explanation on PlayerPrefs.
+    * PlayerPrefs is a key-value database that persists outside of Unity.
+    * I figured we didn't need anything super fancy or secure to keep track of progress.
+    * I don't think anyone would care if our game allowed you to just unlock all the levels by editing a file.
+    * I've replaced the static variables here with calls to the database, that way progress is saved between runs.
+    */
 
     public LevelState(string name)
     {
         this.name = name;
+        PlayerPrefs.SetInt(name + "_locked", 1);
+        PlayerPrefs.SetInt(name + "_stars", 0);
     }
 
     public string getName(){ return name; }
-    public bool getIsLockedLevel(){ return isLockedLevel; }
-    public void setIsLockedLevel(bool isLocked){ isLockedLevel = isLocked; }
-    public int getStarCount(){ return starCount; }
-    public void setStartCount(int stars){ starCount = stars; }
+    public bool getIsLockedLevel(){ return PlayerPrefs.GetInt(name + "_locked") == 1; }
+    public void setIsLockedLevel(bool isLocked){PlayerPrefs.SetInt(name + "_locked", isLocked? 1:0); }
+    public int getStarCount(){ return PlayerPrefs.GetInt(name + "_stars"); }
+    public void setStartCount(int stars){ PlayerPrefs.SetInt(name + "_stars", stars); }
 }
 
 public static class LevelStates
@@ -34,26 +44,27 @@ public static class LevelStates
         {
             // Init LevelState objects, name them based on folder name
             states[i] = new LevelState(new DirectoryInfo(levelDirs[i]).Name);
+        //     // Load Level Metadata using the first LevelMetadataScriptableObject found in the folder
+        //     string levelDir = Path.Combine("Assets/LevelData/MetaData", new DirectoryInfo(levelDirs[i]).Name);
+        //     string[] guid = AssetDatabase.FindAssets("t:LevelMetadataScriptableObject", new[] { levelDir });
+        //     if (guid.Length > 0)
+        //     {
+        //         metadata[i] = AssetDatabase.LoadAssetAtPath<LevelMetadataScriptableObject>(AssetDatabase.GUIDToAssetPath(guid[0]));
+        //     }
+        //     else
+        //     {
+        //         Debug.LogError("No LevelMetadataScriptableObject found within " + levelDir);
+        //         metadata[i] = new LevelMetadataScriptableObject();
+        //     }
 
-            // Load Level Metadata using the first LevelMetadataScriptableObject found in the folder
-            string levelDir = Path.Combine("Assets/LevelData/MetaData", new DirectoryInfo(levelDirs[i]).Name);
-            string[] guid = AssetDatabase.FindAssets("t:LevelMetadataScriptableObject", new[] { levelDir });
-            if (guid.Length > 0)
-            {
-                metadata[i] = AssetDatabase.LoadAssetAtPath<LevelMetadataScriptableObject>(AssetDatabase.GUIDToAssetPath(guid[0]));
-            }
-            else
-            {
-                Debug.LogError("No LevelMetadataScriptableObject found within " + levelDir);
-                metadata[i] = new LevelMetadataScriptableObject();
-            }
-
-            // Unlock levels that do not have prerequisites
-            if (metadata[i].prerequisiteLevel == null || metadata[i].prerequisiteLevel.Trim() == ""){
-                states[i].setIsLockedLevel(false);
-            }
+        // // Unlock levels that do not have prerequisites
+        // if (metadata[i].prerequisiteLevel == null || metadata[i].prerequisiteLevel.Trim() == ""){
+        //     states[i].setIsLockedLevel(false);
+        // }
         }
     }
+
+    public static void setMetadataReference(int levelIndex, LevelMetadataScriptableObject levelMetadata){ metadata[levelIndex] = levelMetadata; }
 
     public static int getNumStates(){ return states.Length; }
     public static bool getIsLockedLevel(int levelIndex){ return states[levelIndex].getIsLockedLevel(); }

--- a/Assets/LevelData/LevelStates.cs
+++ b/Assets/LevelData/LevelStates.cs
@@ -32,40 +32,48 @@ public class LevelState
 
 public static class LevelStates
 {
-    private static int numStates = Directory.GetDirectories(Application.dataPath + "/LevelData/MetaData").Length;
-    private static LevelState[] states = new LevelState[numStates];
-    private static LevelMetadataScriptableObject[] metadata = new LevelMetadataScriptableObject[numStates];
+    private static int numStates = 0;
+    private static LevelState[] states;
+    private static LevelMetadataScriptableObject[] metadata;
 
     static LevelStates()
     {
-        string[] levelDirs = Directory.GetDirectories(Application.dataPath + "/LevelData/MetaData");
+        // string[] levelDirs = Directory.GetDirectories(Application.dataPath + "/LevelData/MetaData");
 
-        for (int i = 0; i < numStates; i++)
-        {
-            // Init LevelState objects, name them based on folder name
-            states[i] = new LevelState(new DirectoryInfo(levelDirs[i]).Name);
-        //     // Load Level Metadata using the first LevelMetadataScriptableObject found in the folder
-        //     string levelDir = Path.Combine("Assets/LevelData/MetaData", new DirectoryInfo(levelDirs[i]).Name);
-        //     string[] guid = AssetDatabase.FindAssets("t:LevelMetadataScriptableObject", new[] { levelDir });
-        //     if (guid.Length > 0)
-        //     {
-        //         metadata[i] = AssetDatabase.LoadAssetAtPath<LevelMetadataScriptableObject>(AssetDatabase.GUIDToAssetPath(guid[0]));
-        //     }
-        //     else
-        //     {
-        //         Debug.LogError("No LevelMetadataScriptableObject found within " + levelDir);
-        //         metadata[i] = new LevelMetadataScriptableObject();
-        //     }
+        // for (int i = 0; i < numStates; i++)
+        // {
+        //     // Init LevelState objects, name them based on folder name
+        //     states[i] = new LevelState(new DirectoryInfo(levelDirs[i]).Name);
+        // //     // Load Level Metadata using the first LevelMetadataScriptableObject found in the folder
+        // //     string levelDir = Path.Combine("Assets/LevelData/MetaData", new DirectoryInfo(levelDirs[i]).Name);
+        // //     string[] guid = AssetDatabase.FindAssets("t:LevelMetadataScriptableObject", new[] { levelDir });
+        // //     if (guid.Length > 0)
+        // //     {
+        // //         metadata[i] = AssetDatabase.LoadAssetAtPath<LevelMetadataScriptableObject>(AssetDatabase.GUIDToAssetPath(guid[0]));
+        // //     }
+        // //     else
+        // //     {
+        // //         Debug.LogError("No LevelMetadataScriptableObject found within " + levelDir);
+        // //         metadata[i] = new LevelMetadataScriptableObject();
+        // //     }
 
-        // // Unlock levels that do not have prerequisites
-        // if (metadata[i].prerequisiteLevel == null || metadata[i].prerequisiteLevel.Trim() == ""){
-        //     states[i].setIsLockedLevel(false);
+        // // // Unlock levels that do not have prerequisites
+        // // if (metadata[i].prerequisiteLevel == null || metadata[i].prerequisiteLevel.Trim() == ""){
+        // //     states[i].setIsLockedLevel(false);
+        // // }
         // }
-        }
     }
 
-    public static void setMetadataReference(int levelIndex, LevelMetadataScriptableObject levelMetadata){ metadata[levelIndex] = levelMetadata; }
-
+    public static void initializeStatesAndMetadata(LevelMetadataScriptableObject[] levelMetadataScriptables)
+    {
+        states = new LevelState[numStates];
+        metadata = levelMetadataScriptables;
+        for(int i = 0; i < numStates; i++)
+        {
+            states[i] = new LevelState(metadata[i].levelName);
+        }
+    }
+    public static void setNumStates(int n){ numStates = n; }
     public static int getNumStates(){ return states.Length; }
     public static bool getIsLockedLevel(int levelIndex){ return states[levelIndex].getIsLockedLevel(); }
     public static void setIsLockedLevel(int levelIndex, bool isLocked){ states[levelIndex].setIsLockedLevel(isLocked); }

--- a/Assets/LevelData/LevelStates.cs
+++ b/Assets/LevelData/LevelStates.cs
@@ -19,15 +19,28 @@ public class LevelState
     public LevelState(string name)
     {
         this.name = name;
-        PlayerPrefs.SetInt(name + "_locked", 1);
-        PlayerPrefs.SetInt(name + "_stars", 0);
     }
 
     public string getName(){ return name; }
-    public bool getIsLockedLevel(){ return PlayerPrefs.GetInt(name + "_locked") == 1; }
-    public void setIsLockedLevel(bool isLocked){PlayerPrefs.SetInt(name + "_locked", isLocked? 1:0); }
-    public int getStarCount(){ return PlayerPrefs.GetInt(name + "_stars"); }
-    public void setStartCount(int stars){ PlayerPrefs.SetInt(name + "_stars", stars); }
+    public bool getIsLockedLevel()
+    {
+        Debug.Log($"LevelState: PlayerPrefs GET {name + "_locked"}: {PlayerPrefs.GetInt(name + "_locked")} ");
+        return PlayerPrefs.GetInt(name + "_locked", 1) == 1; // default locked;
+    }
+    public void setIsLockedLevel(bool isLocked)
+    {
+        Debug.Log($"LevelState: PlayerPrefs SET {name + "_locked"}: {(isLocked? 1:0)} ");
+        PlayerPrefs.SetInt(name + "_locked", isLocked? 1:0);
+    }
+    public int getStarCount()
+    {
+        Debug.Log($"LevelState: PlayerPrefs GET {name + "_stars"}: {PlayerPrefs.GetInt(name + "_stars")} ");
+        return PlayerPrefs.GetInt(name + "_stars", 0); // default 0 stars
+    }
+    public void setStartCount(int stars){
+        Debug.Log($"LevelState: PlayerPrefs GET {name + "_stars"}: {stars}");
+        PlayerPrefs.SetInt(name + "_stars", stars);
+    }
 }
 
 public static class LevelStates

--- a/Assets/LevelData/MetaData/Level2/Level2MetaData.asset
+++ b/Assets/LevelData/MetaData/Level2/Level2MetaData.asset
@@ -12,7 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 60f1ca9347ec87b8fac4d12923002bf8, type: 3}
   m_Name: Level2MetaData
   m_EditorClassIdentifier: 
+  levelName: Level2
   maxStarCount: 3
   prerequisiteLevel: Level1
   levelTutorialEvents: []
   levelHints: []
+  levelThumbnail: {fileID: 21300000, guid: 56d0bf9918391be7c9da98a08e761e34, type: 3}

--- a/Assets/LevelData/MetaData/Level3/Level3MetaData.asset
+++ b/Assets/LevelData/MetaData/Level3/Level3MetaData.asset
@@ -12,7 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 60f1ca9347ec87b8fac4d12923002bf8, type: 3}
   m_Name: Level3MetaData
   m_EditorClassIdentifier: 
+  levelName: Level3
   maxStarCount: 3
   prerequisiteLevel: Level2
   levelTutorialEvents: []
   levelHints: []
+  levelThumbnail: {fileID: 21300000, guid: 2404fac7890478675b7284b85001e800, type: 3}

--- a/Assets/LevelData/MetaData/Level4/Level4MetaData.asset
+++ b/Assets/LevelData/MetaData/Level4/Level4MetaData.asset
@@ -12,7 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 60f1ca9347ec87b8fac4d12923002bf8, type: 3}
   m_Name: Level4MetaData
   m_EditorClassIdentifier: 
+  levelName: Level4
   maxStarCount: 3
   prerequisiteLevel: Level3
   levelTutorialEvents: []
   levelHints: []
+  levelThumbnail: {fileID: 21300000, guid: 60de5260adeeaea4dbb13508a4d3d20f, type: 3}

--- a/Assets/LevelData/Thumbnails/Level3.png.meta
+++ b/Assets/LevelData/Thumbnails/Level3.png.meta
@@ -6,7 +6,7 @@ TextureImporter:
   serializedVersion: 13
   mipmaps:
     mipMapMode: 0
-    enableMipMap: 1
+    enableMipMap: 0
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
@@ -37,13 +37,13 @@ TextureImporter:
     filterMode: 1
     aniso: 1
     mipBias: 0
-    wrapU: 0
-    wrapV: 0
+    wrapU: 1
+    wrapV: 1
     wrapW: 0
-  nPOTScale: 1
+  nPOTScale: 0
   lightmap: 0
   compressionQuality: 50
-  spriteMode: 0
+  spriteMode: 1
   spriteExtrude: 1
   spriteMeshType: 1
   alignment: 0
@@ -52,9 +52,9 @@ TextureImporter:
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
-  alphaIsTransparency: 0
+  alphaIsTransparency: 1
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 8
   textureShape: 1
   singleChannelComponent: 0
   flipbookRows: 1
@@ -125,7 +125,7 @@ TextureImporter:
     outline: []
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: 5e97eb03825dee720800000000000000
     internalID: 0
     vertices: []
     indices: 

--- a/Assets/LevelData/Thumbnails/Level4.png.meta
+++ b/Assets/LevelData/Thumbnails/Level4.png.meta
@@ -6,7 +6,7 @@ TextureImporter:
   serializedVersion: 13
   mipmaps:
     mipMapMode: 0
-    enableMipMap: 1
+    enableMipMap: 0
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
@@ -37,13 +37,13 @@ TextureImporter:
     filterMode: 1
     aniso: 1
     mipBias: 0
-    wrapU: 0
-    wrapV: 0
+    wrapU: 1
+    wrapV: 1
     wrapW: 0
-  nPOTScale: 1
+  nPOTScale: 0
   lightmap: 0
   compressionQuality: 50
-  spriteMode: 0
+  spriteMode: 1
   spriteExtrude: 1
   spriteMeshType: 1
   alignment: 0
@@ -52,9 +52,9 @@ TextureImporter:
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
-  alphaIsTransparency: 0
+  alphaIsTransparency: 1
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 8
   textureShape: 1
   singleChannelComponent: 0
   flipbookRows: 1
@@ -125,7 +125,7 @@ TextureImporter:
     outline: []
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: 5e97eb03825dee720800000000000000
     internalID: 0
     vertices: []
     indices: 

--- a/Assets/LevelStatesManager.cs
+++ b/Assets/LevelStatesManager.cs
@@ -1,0 +1,22 @@
+using System.Collections;
+using System.Collections.Generic;
+using Unity.VisualScripting;
+using UnityEngine;
+
+public class LevelStatesManager : MonoBehaviour
+{
+    public LevelMetadataScriptableObject[] levelMetadataScriptables;
+
+    void Awake()
+    {
+        DontDestroyOnLoad(this.gameObject);    
+    }
+
+    void Start()
+    {
+        // Initializing LevelStates...
+        LevelStates.setNumStates(levelMetadataScriptables.Length);
+        LevelStates.initializeStatesAndMetadata(levelMetadataScriptables);
+        LevelStates.triggerPrerequisiteLevelUnlock("");
+    }
+}

--- a/Assets/LevelStatesManager.cs.meta
+++ b/Assets/LevelStatesManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 61ffa460ae8226a449e085134fda18d0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Basic Level View.unity
+++ b/Assets/Scenes/Basic Level View.unity
@@ -4708,6 +4708,7 @@ GameObject:
   - component: {fileID: 416215825}
   - component: {fileID: 416215824}
   - component: {fileID: 416215827}
+  - component: {fileID: 416215828}
   m_Layer: 0
   m_Name: XR Origin (XR Rig)
   m_TagString: Untagged
@@ -4778,6 +4779,20 @@ MonoBehaviour:
   RightHand: {fileID: 0}
   XRControllerLeft: {fileID: 0}
   XRControllerRight: {fileID: 0}
+--- !u!114 &416215828
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 416215823}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 03a5df2202a8b96488c744be3bd0c33e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Timeout: 10
+  m_XROrigin: {fileID: 416215825}
 --- !u!1001 &418739506
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7756,7 +7771,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6598815579406187037, guid: 18ddb545287c546e19cc77dc9fbb2189, type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -9911,15 +9926,15 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3475118261464492563, guid: 9f3369e30fbd31f4bb596b1a99babe83, type: 3}
       propertyPath: m_LocalScale.x
-      value: 3.5367
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3475118261464492563, guid: 9f3369e30fbd31f4bb596b1a99babe83, type: 3}
       propertyPath: m_LocalScale.y
-      value: 3.5367
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3475118261464492563, guid: 9f3369e30fbd31f4bb596b1a99babe83, type: 3}
       propertyPath: m_LocalScale.z
-      value: 3.5367
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3475118261464492563, guid: 9f3369e30fbd31f4bb596b1a99babe83, type: 3}
       propertyPath: m_LocalPosition.x
@@ -14434,15 +14449,15 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 8270855663187062767, guid: 1392f805216c47742996d4742c80721c, type: 3}
       propertyPath: m_LocalScale.x
-      value: 3.5367
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8270855663187062767, guid: 1392f805216c47742996d4742c80721c, type: 3}
       propertyPath: m_LocalScale.y
-      value: 3.5367
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8270855663187062767, guid: 1392f805216c47742996d4742c80721c, type: 3}
       propertyPath: m_LocalScale.z
-      value: 3.5367
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8270855663187062767, guid: 1392f805216c47742996d4742c80721c, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Scenes/Intro View.unity
+++ b/Assets/Scenes/Intro View.unity
@@ -4315,6 +4315,11 @@ MonoBehaviour:
   middleLevelView: {fileID: 282266609}
   leftLevelView: {fileID: 413289342}
   rightLevelView: {fileID: 2104979130}
+  levelMetadataScriptables:
+  - {fileID: 11400000, guid: bd47bb387ab4cdb6eb0a91e72d026dae, type: 2}
+  - {fileID: 11400000, guid: 2fd2c8f5e96284ec0894b2ac0301c537, type: 2}
+  - {fileID: 11400000, guid: 8f6266ce3c1eb33e4875e64f789bec24, type: 2}
+  - {fileID: 11400000, guid: 85cf979bcd1aec33092f614218595556, type: 2}
 --- !u!1 &1620565657
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Intro View.unity
+++ b/Assets/Scenes/Intro View.unity
@@ -539,6 +539,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   waitDuration: 1
+  levelMetadataScriptables: []
 --- !u!4 &231684126
 Transform:
   m_ObjectHideFlags: 0
@@ -1742,7 +1743,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6598815579406187037, guid: 18ddb545287c546e19cc77dc9fbb2189, type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -2583,7 +2584,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 994881666}
-  - component: {fileID: 994881665}
+  - component: {fileID: 994881667}
   m_Layer: 0
   m_Name: LevelStatesManager
   m_TagString: Untagged
@@ -2591,18 +2592,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &994881665
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 994881664}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ecc1535de194c62d89a1b8c5faf23890, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!4 &994881666
 Transform:
   m_ObjectHideFlags: 0
@@ -2618,6 +2607,23 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &994881667
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 994881664}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 61ffa460ae8226a449e085134fda18d0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  levelMetadataScriptables:
+  - {fileID: 11400000, guid: bd47bb387ab4cdb6eb0a91e72d026dae, type: 2}
+  - {fileID: 11400000, guid: 2fd2c8f5e96284ec0894b2ac0301c537, type: 2}
+  - {fileID: 11400000, guid: 8f6266ce3c1eb33e4875e64f789bec24, type: 2}
+  - {fileID: 11400000, guid: 85cf979bcd1aec33092f614218595556, type: 2}
 --- !u!1 &1011742837
 GameObject:
   m_ObjectHideFlags: 0
@@ -4315,11 +4321,6 @@ MonoBehaviour:
   middleLevelView: {fileID: 282266609}
   leftLevelView: {fileID: 413289342}
   rightLevelView: {fileID: 2104979130}
-  levelMetadataScriptables:
-  - {fileID: 11400000, guid: bd47bb387ab4cdb6eb0a91e72d026dae, type: 2}
-  - {fileID: 11400000, guid: 2fd2c8f5e96284ec0894b2ac0301c537, type: 2}
-  - {fileID: 11400000, guid: 8f6266ce3c1eb33e4875e64f789bec24, type: 2}
-  - {fileID: 11400000, guid: 85cf979bcd1aec33092f614218595556, type: 2}
 --- !u!1 &1620565657
 GameObject:
   m_ObjectHideFlags: 0
@@ -4959,8 +4960,7 @@ Transform:
   m_LocalPosition: {x: -4.4052854, y: -5.230321, z: 10.936094}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1965819278}
+  m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &1860171386 stripped
@@ -5327,12 +5327,12 @@ Transform:
   m_GameObject: {fileID: 1965819275}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 4.4052854, y: 5.230321, z: -10.936094}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1828088530}
-  m_Father: {fileID: 1850122190}
+  m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2064898091
 GameObject:
@@ -5634,6 +5634,7 @@ SceneRoots:
   - {fileID: 1050561326}
   - {fileID: 1620565661}
   - {fileID: 534281612}
+  - {fileID: 1965819278}
   - {fileID: 1850122190}
   - {fileID: 2108290993}
   - {fileID: 1051434122}

--- a/Assets/Scenes/PlayableLevels/Level1.unity
+++ b/Assets/Scenes/PlayableLevels/Level1.unity
@@ -1805,7 +1805,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6598815579406187037, guid: 18ddb545287c546e19cc77dc9fbb2189, type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -4095,6 +4095,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   waitDuration: 1
+  levelMetadataScriptables: []
 --- !u!4 &221714453
 Transform:
   m_ObjectHideFlags: 0
@@ -6196,6 +6197,7 @@ MonoBehaviour:
   turtleMovement: {fileID: 1237249628}
   startBlock: {fileID: 1638255123}
   startButton: {fileID: 885789290}
+  blockCount: {fileID: 0}
 --- !u!4 &358159623
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/PlayableLevels/Level2.unity
+++ b/Assets/Scenes/PlayableLevels/Level2.unity
@@ -1751,7 +1751,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6598815579406187037, guid: 18ddb545287c546e19cc77dc9fbb2189, type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -4452,6 +4452,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   waitDuration: 1
+  levelMetadataScriptables: []
 --- !u!4 &221714453
 Transform:
   m_ObjectHideFlags: 0
@@ -6464,6 +6465,7 @@ MonoBehaviour:
   turtleMovement: {fileID: 2131428316}
   startBlock: {fileID: 58221690}
   startButton: {fileID: 885789290}
+  blockCount: {fileID: 0}
 --- !u!4 &348187168
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/PlayableLevels/Level3.unity
+++ b/Assets/Scenes/PlayableLevels/Level3.unity
@@ -5186,6 +5186,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   waitDuration: 1
+  levelMetadataScriptables: []
 --- !u!4 &400394272
 Transform:
   m_ObjectHideFlags: 0
@@ -12042,6 +12043,7 @@ MonoBehaviour:
   turtleMovement: {fileID: 1316989591}
   startBlock: {fileID: 1694751828}
   startButton: {fileID: 1059108139}
+  blockCount: {fileID: 0}
 --- !u!4 &1027230819
 Transform:
   m_ObjectHideFlags: 0
@@ -24575,7 +24577,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6598815579406187037, guid: 18ddb545287c546e19cc77dc9fbb2189, type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Scenes/PlayableLevels/Level4.unity
+++ b/Assets/Scenes/PlayableLevels/Level4.unity
@@ -1422,7 +1422,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6598815579406187037, guid: 18ddb545287c546e19cc77dc9fbb2189, type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -7366,6 +7366,7 @@ MonoBehaviour:
   turtleMovement: {fileID: 1565355708}
   startBlock: {fileID: 849021786}
   startButton: {fileID: 639692978}
+  blockCount: {fileID: 0}
 --- !u!4 &645675149
 Transform:
   m_ObjectHideFlags: 0
@@ -22040,6 +22041,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   waitDuration: 1
+  levelMetadataScriptables: []
 --- !u!4 &2035720379
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Menus/LevelSelectorMenu.cs
+++ b/Assets/Scripts/Menus/LevelSelectorMenu.cs
@@ -33,6 +33,20 @@ public class LevelSelectorMenu : MonoBehaviour
     private Vector2 leftLevelViewScale;
     private Vector2 rightLevelViewScale;
 
+    /*
+    * Okay, this may be a little weird and hard to justify.
+    * I set out to remove the dependency on AssetDatabase by LevelStates.
+    * I considered moving the LevelMetadataScriptableObject(s) to Resources, and using Resources.Load().
+    * Ultimately, I wanted to disrupt the current functioning of LevelStates as little as possible.
+    * What I really needed was a way to configure LevelStates with hardcoded references to the LevelMetadataScriptableObject(s).
+    * This way, it wouldn't need to load them at runtime via AssetDatabase.
+    * I can't do this unfortunately, but I figured that this object is the first object in the whole game that needs LevelStates
+    * to be complete, so why not give it hardcoded references to the ScriptableObjects in the Editor, and then have it load up LevelStates itself.
+    * All the other objects that reference it, like PlayerUIManager, should find it in a ready state when they are initialized.
+    */
+
+    public LevelMetadataScriptableObject[] levelMetadataScriptables;
+
     void Awake()
     {
         // Animations
@@ -50,6 +64,13 @@ public class LevelSelectorMenu : MonoBehaviour
 
     void Start()
     {
+        // Initializing LevelStates...
+        for(int i = 0; i < levelMetadataScriptables.Length; i++)
+        {
+            LevelStates.setMetadataReference(i, levelMetadataScriptables[i]);
+        }
+        LevelStates.triggerPrerequisiteLevelUnlock("");
+
         // Long winded way of grabbing the thumbnails. Wished Resource.LoadAll worked
         DirectoryInfo thumbnailDir = new DirectoryInfo(Application.dataPath + "/LevelData/Thumbnails");
         FileInfo[] thumbnailFiles = thumbnailDir.GetFiles("*.png");

--- a/Assets/Scripts/Menus/LevelSelectorMenu.cs
+++ b/Assets/Scripts/Menus/LevelSelectorMenu.cs
@@ -90,7 +90,7 @@ public class LevelSelectorMenu : MonoBehaviour
 
     public void GoToLevel()
     {
-        SceneTransitionManager.singleton.GoToSceneAsync(selectedLevelIndex, LoadSceneBy.AssetDirectoryOrder);
+        SceneTransitionManager.singleton.GoToSceneAsync(selectedLevelIndex, LoadSceneBy.LevelStatesManagerArrayOrder);
         // SceneTransitionManager.singleton.GoToSceneAsync(selectedLevelIndex, LoadSceneBy.BuildSettingsOrder);
         SceneTransitionStates.SetSelectedLevel(selectedLevelIndex);
     }

--- a/Assets/Scripts/Menus/LevelSelectorMenu.cs
+++ b/Assets/Scripts/Menus/LevelSelectorMenu.cs
@@ -33,20 +33,6 @@ public class LevelSelectorMenu : MonoBehaviour
     private Vector2 leftLevelViewScale;
     private Vector2 rightLevelViewScale;
 
-    /*
-    * Okay, this may be a little weird and hard to justify.
-    * I set out to remove the dependency on AssetDatabase by LevelStates.
-    * I considered moving the LevelMetadataScriptableObject(s) to Resources, and using Resources.Load().
-    * Ultimately, I wanted to disrupt the current functioning of LevelStates as little as possible.
-    * What I really needed was a way to configure LevelStates with hardcoded references to the LevelMetadataScriptableObject(s).
-    * This way, it wouldn't need to load them at runtime via AssetDatabase.
-    * I can't do this unfortunately, but I figured that this object is the first object in the whole game that needs LevelStates
-    * to be complete, so why not give it hardcoded references to the ScriptableObjects in the Editor, and then have it load up LevelStates itself.
-    * All the other objects that reference it, like PlayerUIManager, should find it in a ready state when they are initialized.
-    */
-
-    public LevelMetadataScriptableObject[] levelMetadataScriptables;
-
     void Awake()
     {
         // Animations
@@ -64,26 +50,25 @@ public class LevelSelectorMenu : MonoBehaviour
 
     void Start()
     {
-        // Initializing LevelStates...
+        // Long winded way of grabbing the thumbnails. Wished Resource.LoadAll worked
+        // DirectoryInfo thumbnailDir = new DirectoryInfo(Application.dataPath + "/LevelData/Thumbnails");
+        // FileInfo[] thumbnailFiles = thumbnailDir.GetFiles("*.png");
+        // levelThumbnails = new Sprite[thumbnailFiles.Length];
+        // for (int i = 0; i < thumbnailFiles.Length; i++)
+        // {
+        //     Texture2D tex = new Texture2D(2, 2);                                // Texture size should not matter (https://discussions.unity.com/t/how-to-load-a-texture2d-from-path-without-resources-load/796449/6)
+        //     tex.LoadImage(File.ReadAllBytes(thumbnailFiles[i].FullName));
+        //     levelThumbnails[i] = Sprite.Create(
+        //         tex,
+        //         new Rect(0.0f, 0.0f, tex.width, tex.height),
+        //         new Vector2(0.5f, 0.5f)
+        //     );
+        // }
+        LevelMetadataScriptableObject[] levelMetadataScriptables = GameObject.Find("/LevelStatesManager").GetComponent<LevelStatesManager>().levelMetadataScriptables;
+        levelThumbnails = new Sprite[levelMetadataScriptables.Length];
         for(int i = 0; i < levelMetadataScriptables.Length; i++)
         {
-            LevelStates.setMetadataReference(i, levelMetadataScriptables[i]);
-        }
-        LevelStates.triggerPrerequisiteLevelUnlock("");
-
-        // Long winded way of grabbing the thumbnails. Wished Resource.LoadAll worked
-        DirectoryInfo thumbnailDir = new DirectoryInfo(Application.dataPath + "/LevelData/Thumbnails");
-        FileInfo[] thumbnailFiles = thumbnailDir.GetFiles("*.png");
-        levelThumbnails = new Sprite[thumbnailFiles.Length];
-        for (int i = 0; i < thumbnailFiles.Length; i++)
-        {
-            Texture2D tex = new Texture2D(2, 2);                                // Texture size should not matter (https://discussions.unity.com/t/how-to-load-a-texture2d-from-path-without-resources-load/796449/6)
-            tex.LoadImage(File.ReadAllBytes(thumbnailFiles[i].FullName));
-            levelThumbnails[i] = Sprite.Create(
-                tex,
-                new Rect(0.0f, 0.0f, tex.width, tex.height),
-                new Vector2(0.5f, 0.5f)
-            );
+            levelThumbnails[i] = levelMetadataScriptables[i].levelThumbnail;
         }
 
         playLevelButton.onClick.AddListener(GoToLevel);

--- a/Assets/Scripts/Menus/PlayerUIManager.cs
+++ b/Assets/Scripts/Menus/PlayerUIManager.cs
@@ -194,6 +194,7 @@ public class PlayerUIManager : MonoBehaviour
         }
 
         // Unlock all other levels that require this one as a prerequisite
+        Debug.Log($"PlayerUIManager.EnableEndScreen: unlocking prerequisites for {SceneTransitionStates.GetSelectedLevel()}");
         LevelStates.triggerPrerequisiteLevelUnlock(SceneTransitionStates.GetSelectedLevel());
 
         //TODO: If we want the option to allow players to play around in the level after completing, these need to go

--- a/Assets/Scripts/Menus/PlayerUIManager.cs
+++ b/Assets/Scripts/Menus/PlayerUIManager.cs
@@ -148,7 +148,7 @@ public class PlayerUIManager : MonoBehaviour
         blockMenuAction.action.Enable();
         int nextLevel = SceneTransitionStates.GetSelectedLevel() + 1;
         SceneTransitionStates.SetSelectedLevel(nextLevel);
-        SceneTransitionManager.singleton.GoToSceneAsync(nextLevel, LoadSceneBy.AssetDirectoryOrder);
+        SceneTransitionManager.singleton.GoToSceneAsync(nextLevel, LoadSceneBy.LevelStatesManagerArrayOrder);
     }
 
     public void ToggleBlockMenu()
@@ -182,9 +182,10 @@ public class PlayerUIManager : MonoBehaviour
         toggleBlockMenu = false;
 
         // Show "Next Level" Button only if the current level is not the last playable level
-        DirectoryInfo thumbnailDir = new DirectoryInfo(Application.dataPath + "/LevelData/Thumbnails");
-        FileInfo[] fin = thumbnailDir.GetFiles("*.png");
-        if(SceneTransitionStates.GetSelectedLevel() + 1 >= fin.Length){
+        // DirectoryInfo thumbnailDir = new DirectoryInfo(Application.dataPath + "/LevelData/Thumbnails");
+        LevelMetadataScriptableObject[] levelMetadataScriptables = GameObject.Find("/LevelStatesManager").GetComponent<LevelStatesManager>().levelMetadataScriptables;
+        // FileInfo[] fin = thumbnailDir.GetFiles("*.png");
+        if(SceneTransitionStates.GetSelectedLevel() + 1 >= levelMetadataScriptables.Length){
             nextLevelButton.GameObject().LeanScale(Vector3.zero, 0f);
             endScreenReturnToMenu.GameObject().LeanScale(Vector3.zero, 0f);
         }

--- a/Assets/Scripts/Menus/SceneTransitionManager.cs
+++ b/Assets/Scripts/Menus/SceneTransitionManager.cs
@@ -8,7 +8,7 @@ using UnityEngine.SceneManagement;
 
 public enum LoadSceneBy
 {
-    AssetDirectoryOrder = 0,
+    LevelStatesManagerArrayOrder = 0,
     BuildSettingsOrder = 1
 }
 public class SceneTransitionManager : MonoBehaviour
@@ -36,7 +36,7 @@ public class SceneTransitionManager : MonoBehaviour
 
         singleton = this;
     }
-    public void GoToScene(int sceneIndex, LoadSceneBy loadOption = LoadSceneBy.AssetDirectoryOrder)
+    public void GoToScene(int sceneIndex, LoadSceneBy loadOption = LoadSceneBy.LevelStatesManagerArrayOrder)
     {
         StartCoroutine(GoToSceneRoutine(sceneIndex, loadOption));
     }
@@ -48,7 +48,7 @@ public class SceneTransitionManager : MonoBehaviour
     IEnumerator GoToSceneRoutine(int sceneIndex, LoadSceneBy loadOption)
     {
         yield return new WaitForSeconds(waitDuration);
-        if (loadOption == LoadSceneBy.AssetDirectoryOrder)
+        if (loadOption == LoadSceneBy.LevelStatesManagerArrayOrder)
         {
             SceneManager.LoadScene(levelMetadataScriptables[sceneIndex].levelName);
         }
@@ -63,7 +63,7 @@ public class SceneTransitionManager : MonoBehaviour
         SceneManager.LoadScene(sceneName);
     }
 
-    public void GoToSceneAsync(int sceneIndex, LoadSceneBy loadOption = LoadSceneBy.AssetDirectoryOrder)
+    public void GoToSceneAsync(int sceneIndex, LoadSceneBy loadOption = LoadSceneBy.LevelStatesManagerArrayOrder)
     {
         StartCoroutine(GoToSceneAsyncRoutine(sceneIndex, loadOption));
     }
@@ -75,7 +75,7 @@ public class SceneTransitionManager : MonoBehaviour
     IEnumerator GoToSceneAsyncRoutine(int sceneIndex, LoadSceneBy loadOption)
     {
         AsyncOperation operation;
-        if (loadOption == LoadSceneBy.AssetDirectoryOrder)
+        if (loadOption == LoadSceneBy.LevelStatesManagerArrayOrder)
         {
             Debug.Log($"SceneTransitionManager.GoToSceneAsyncRoutine: sceneIndex:{sceneIndex}");
             foreach(LevelMetadataScriptableObject lmso in levelMetadataScriptables)

--- a/Assets/Scripts/Menus/SceneTransitionManager.cs
+++ b/Assets/Scripts/Menus/SceneTransitionManager.cs
@@ -16,12 +16,15 @@ public class SceneTransitionManager : MonoBehaviour
     public int waitDuration;
     public static SceneTransitionManager singleton;
 
-    public static FileInfo[] scenes;
+    // public static FileInfo[] scenes;
+
+    public LevelMetadataScriptableObject[] levelMetadataScriptables;
 
     public void Start()
     {
-        DirectoryInfo dir = new DirectoryInfo(Application.dataPath + "/Scenes/PlayableLevels");
-        scenes = dir.GetFiles("*.unity");
+        // DirectoryInfo dir = new DirectoryInfo(Application.dataPath + "/Scenes/PlayableLevels");
+        // scenes = dir.GetFiles("*.unity");
+        levelMetadataScriptables = GameObject.Find("/LevelStatesManager").GetComponent<LevelStatesManager>().levelMetadataScriptables;
     }
 
     private void Awake()
@@ -33,7 +36,6 @@ public class SceneTransitionManager : MonoBehaviour
 
         singleton = this;
     }
-
     public void GoToScene(int sceneIndex, LoadSceneBy loadOption = LoadSceneBy.AssetDirectoryOrder)
     {
         StartCoroutine(GoToSceneRoutine(sceneIndex, loadOption));
@@ -48,7 +50,7 @@ public class SceneTransitionManager : MonoBehaviour
         yield return new WaitForSeconds(waitDuration);
         if (loadOption == LoadSceneBy.AssetDirectoryOrder)
         {
-            SceneManager.LoadScene(scenes[sceneIndex].Name.Replace(".unity", ""));
+            SceneManager.LoadScene(levelMetadataScriptables[sceneIndex].levelName);
         }
         else if (loadOption == LoadSceneBy.BuildSettingsOrder)
         {
@@ -75,7 +77,12 @@ public class SceneTransitionManager : MonoBehaviour
         AsyncOperation operation;
         if (loadOption == LoadSceneBy.AssetDirectoryOrder)
         {
-            operation = SceneManager.LoadSceneAsync(scenes[sceneIndex].Name.Replace(".unity", ""));
+            Debug.Log($"SceneTransitionManager.GoToSceneAsyncRoutine: sceneIndex:{sceneIndex}");
+            foreach(LevelMetadataScriptableObject lmso in levelMetadataScriptables)
+            {
+                Debug.Log(lmso.levelName);
+            }
+            operation = SceneManager.LoadSceneAsync(levelMetadataScriptables[sceneIndex].levelName);
         }
         else // LoadSceneBy.BuildSettingsOrder
         {

--- a/Assets/XR/Loaders/OculusLoader.asset
+++ b/Assets/XR/Loaders/OculusLoader.asset
@@ -9,12 +9,6 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 60f1ca9347ec87b8fac4d12923002bf8, type: 3}
-  m_Name: Level1MetaData
+  m_Script: {fileID: 11500000, guid: 03bc68f14d65e7747a59d5ff74bd199b, type: 3}
+  m_Name: OculusLoader
   m_EditorClassIdentifier: 
-  levelName: Level1
-  maxStarCount: 3
-  prerequisiteLevel: 
-  levelTutorialEvents: []
-  levelHints: []
-  levelThumbnail: {fileID: 21300000, guid: f994dad2f355f38ec8013bb7d3ea7ca5, type: 3}

--- a/Assets/XR/Loaders/OculusLoader.asset.meta
+++ b/Assets/XR/Loaders/OculusLoader.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ea5cee874e716c7b7816cf056c58c7b3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/XR/Settings/OculusSettings.asset
+++ b/Assets/XR/Settings/OculusSettings.asset
@@ -1,0 +1,34 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c353a8f1e58cf884584123914fe63cd5, type: 3}
+  m_Name: OculusSettings
+  m_EditorClassIdentifier: 
+  m_StereoRenderingModeDesktop: 1
+  m_StereoRenderingModeAndroid: 2
+  SharedDepthBuffer: 1
+  DepthSubmission: 0
+  DashSupport: 1
+  LowOverheadMode: 0
+  OptimizeBufferDiscards: 1
+  PhaseSync: 1
+  SymmetricProjection: 1
+  SubsampledLayout: 0
+  FoveatedRenderingMethod: 0
+  LateLatching: 0
+  LateLatchingDebug: 0
+  EnableTrackingOriginStageMode: 0
+  SpaceWarp: 0
+  TargetQuest2: 1
+  TargetQuestPro: 0
+  TargetQuest3: 0
+  SystemSplashScreen: {fileID: 0}
+  UseStickControlThumbsticks: 0

--- a/Assets/XR/Settings/OculusSettings.asset.meta
+++ b/Assets/XR/Settings/OculusSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 10405731ed1e0d45b919d48d10bb08db
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/XR/XRGeneralSettingsPerBuildTarget.asset
+++ b/Assets/XR/XRGeneralSettingsPerBuildTarget.asset
@@ -14,6 +14,20 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_LoaderManagerInstance: {fileID: 8924358954724205928}
   m_InitManagerOnStart: 1
+--- !u!114 &-5298874135848222938
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d236b7d11115f2143951f1e14045df39, type: 3}
+  m_Name: WebGL Settings
+  m_EditorClassIdentifier: 
+  m_LoaderManagerInstance: {fileID: 6770474871395441252}
+  m_InitManagerOnStart: 1
 --- !u!114 &-1327731719605134024
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -30,7 +44,7 @@ MonoBehaviour:
   m_AutomaticLoading: 0
   m_AutomaticRunning: 0
   m_Loaders:
-  - {fileID: 11400000, guid: f0ed02c9ea699f64883ddcc481af3901, type: 2}
+  - {fileID: 11400000, guid: ea5cee874e716c7b7816cf056c58c7b3, type: 2}
 --- !u!114 &11400000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -43,10 +57,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d2dc886499c26824283350fa532d087d, type: 3}
   m_Name: XRGeneralSettingsPerBuildTarget
   m_EditorClassIdentifier: 
-  Keys: 0100000007000000
+  Keys: 01000000070000000d000000
   Values:
   - {fileID: -5838342135374764446}
   - {fileID: 5102545352072659698}
+  - {fileID: -5298874135848222938}
 --- !u!114 &5102545352072659698
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -61,6 +76,22 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_LoaderManagerInstance: {fileID: -1327731719605134024}
   m_InitManagerOnStart: 1
+--- !u!114 &6770474871395441252
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4c3631f5e58749a59194e0cf6baf6d5, type: 3}
+  m_Name: WebGL Providers
+  m_EditorClassIdentifier: 
+  m_RequiresSettingsUpdate: 0
+  m_AutomaticLoading: 0
+  m_AutomaticRunning: 0
+  m_Loaders: []
 --- !u!114 &8924358954724205928
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -10,6 +10,7 @@
     "com.unity.visualscripting": "1.9.4",
     "com.unity.xr.interaction.toolkit": "2.6.3",
     "com.unity.xr.management": "4.5.0",
+    "com.unity.xr.oculus": "4.3.0",
     "com.unity.xr.openxr": "1.12.1",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -230,6 +230,15 @@
       },
       "url": "https://packages.unity.com"
     },
+    "com.unity.xr.oculus": {
+      "version": "4.3.0",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.xr.management": "4.4.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.xr.openxr": {
       "version": "1.12.1",
       "depth": 0,

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -8,7 +8,7 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/Intro View.unity
     guid: 1998b4c1f4521687ca8916eba7987f0c
-  - enabled: 1
+  - enabled: 0
     path: Assets/Scenes/Basic Level View.unity
     guid: bdeb977492a2548f1844701fb30ce03d
   - enabled: 1
@@ -24,6 +24,7 @@ EditorBuildSettings:
     path: Assets/Scenes/PlayableLevels/Level4.unity
     guid: 5af34105eaeb430a5a3913fdda08bd18
   m_configObjects:
+    Unity.XR.Oculus.Settings: {fileID: 11400000, guid: 10405731ed1e0d45b919d48d10bb08db, type: 2}
     com.unity.xr.arfoundation.simulation_settings: {fileID: 11400000, guid: 8535fa5cce2d548608eb21622875058a, type: 2}
     com.unity.xr.management.loader_settings: {fileID: 11400000, guid: ac7005ab61d23a54aa6334a7839952c7, type: 2}
     com.unity.xr.openxr.settings4: {fileID: 11400000, guid: 9d085b406b013d64b94f164dafd69ad6, type: 2}

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -141,10 +141,7 @@ PlayerSettings:
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
   bundleVersion: 0.1
-  preloadedAssets:
-  - {fileID: 5102545352072659698, guid: ac7005ab61d23a54aa6334a7839952c7, type: 2}
-  - {fileID: 11400000, guid: 10405731ed1e0d45b919d48d10bb08db, type: 2}
-  - {fileID: 7163396593790563718, guid: 9d085b406b013d64b94f164dafd69ad6, type: 2}
+  preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -141,8 +141,7 @@ PlayerSettings:
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
   bundleVersion: 0.1
-  preloadedAssets:
-  - {fileID: 819348141126924304, guid: 9d085b406b013d64b94f164dafd69ad6, type: 2}
+  preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -141,7 +141,10 @@ PlayerSettings:
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
   bundleVersion: 0.1
-  preloadedAssets: []
+  preloadedAssets:
+  - {fileID: 5102545352072659698, guid: ac7005ab61d23a54aa6334a7839952c7, type: 2}
+  - {fileID: 11400000, guid: 10405731ed1e0d45b919d48d10bb08db, type: 2}
+  - {fileID: 7163396593790563718, guid: 9d085b406b013d64b94f164dafd69ad6, type: 2}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1


### PR DESCRIPTION
**Treat this PR with care!**
I wanted to test out the project on my Oculus Quest 2 headset, and I encountered several bugs that made the game inoperable when compiled and run on the headset.
Most of these bugs and errors were related to accessing information about the levels directly from the `Assets/` directory, either via `AssetDatabase`, or via `System.IO` calls.
`AssetDatabase` cannot be used outside the Unity Editor, and `System.IO` doesn't behave identically on all platforms.
I went about removing the dependence on these operations, which required some tweaking of the components that used them.

## Changes
- Added `LevelStatesManager`.
`LevelStatesManager` is an object in Intro View, that contains a hardcoded array of references to all existing `LevelMetadataScriptableObject`s, and has called `DontDestroyOnLoad()` on itself. Other objects in the scene that need to access level metadata will fetch this object first. When this object loads, it initializes all values in `LevelStates`.
- Changed `LevelSelectorMenu`, and `SceneTransitionManager` to now depend on `LevelStatesManager`.
- Changed `LevelMetadataScriptableObject` to include a level name string, used to control prerequisite unlocks, and loading new scenes.
- Changed `LevelMetadataScriptableObject` to include a sprite for the thumbnail, so it no longer needs to be fetched from `Assets/`'.
I set these values appropriately.
- Changed the `LevelState` class to `get` and `set` values via calls to `PlayerPrefs`.
`PlayerPrefs` is a key-value store outside of Unity, and thus persists between runs. Users can manipulate this data on their systems, and theoretically unlock all the levels without playing them, but I didn't reckon that's a real concern.
- Changed the pngs for Levels 3 and 4 to be Sprites.
- Added the Oculus support package.


I also changed the build settings to support this.
The Android settings in **Edit > Project Settings > XR Plug-in Management** have been changed to "Oculus",
and the build settings have been changed to "Android".

PC XR still builds for OpenXR, and changing the Platform build target is inconsequential.