### PR TITLE
Bug fix/execution listener stacking bug

### DIFF
--- a/Assets/Scripts/ExecutionDirector.cs
+++ b/Assets/Scripts/ExecutionDirector.cs
@@ -36,7 +36,9 @@ public class ExecutionDirector : MonoBehaviour
         GrabFunctionsInScene();
         turtleMovement.FailEvent.AddListener(FailHandler);
         turtleMovement.SuccessEvent.AddListener(SuccessHandler);
+        turtleMovement.ResetEvent.AddListener(ResetStartButton);
     }
+
     public void StartButtonPressed(SelectEnterEventArgs selectEnter)
     {
         // initialize data structures
@@ -58,8 +60,7 @@ public class ExecutionDirector : MonoBehaviour
         // disable start button
         if(mainBlockList.Count > 0){
             startButton.GetComponent<StartButton>().SetEnabled(false);
-            startButton.GetComponent<XRSimpleInteractable>().selectEntered.RemoveListener(StartButtonPressed);
-            turtleMovement.ResetEvent.AddListener(ResetStartButton);
+            startButton.GetComponent<XRSimpleInteractable>().selectEntered.RemoveAllListeners();
         }
 
         // clear old error messages
@@ -331,6 +332,8 @@ public class ExecutionDirector : MonoBehaviour
     {
         Debug.Log("ExecutionDirector: Failure! Halting..");
         ContinueLoopEvent.RemoveAllListeners();
+
+        // apparently data from previous executions is not getting cleared.
     }
 
     readonly float defaultWait = 1.0f;

--- a/Assets/Scripts/ExecutionDirector.cs
+++ b/Assets/Scripts/ExecutionDirector.cs
@@ -332,8 +332,6 @@ public class ExecutionDirector : MonoBehaviour
     {
         Debug.Log("ExecutionDirector: Failure! Halting..");
         ContinueLoopEvent.RemoveAllListeners();
-
-        // apparently data from previous executions is not getting cleared.
     }
 
     readonly float defaultWait = 1.0f;


### PR DESCRIPTION
I discovered a bug in `ExecutionDirector` where I had a line - `turtleMovement.ResetEvent.AddListener(ResetStartButton);` - that was being called every time the start button was pressed (and the listener was never getting removed), causing the `ResetStartButton` function to be executed an increasing number of times after every execution. 

This, in turn would cause a repeated call of `startButton.GetComponent<XRSimpleInteractable>().selectEntered.AddListener(StartButtonPressed);`, which would of course mean that as the user executed the queue over and over again, there would gradually be more and more instances of `StartButtonPressed()` getting executed simultaneously, creating nasty race conditions, ultimately causing complete failure of the `ExecutionDirector` logic, similar to how the user used to be able to press the start button while execution was already in progress.

I moved around these lines, which fixed the bug.