### PR TITLE
Prevents snapping immediately after grabbing

### DIFF
--- a/Assets/Blocks/Scripts/SnappedForwarding.cs
+++ b/Assets/Blocks/Scripts/SnappedForwarding.cs
@@ -4,6 +4,7 @@ public class SnappedForwarding : MonoBehaviour
 {
     public bool IsRootBlock { get; set; } = true;
     public bool IsSnapped { get; private set; } = false;  // Flag to prevent further snapping
+    public bool snappingEnabled { get; set; } = true;
     public GameObject? ConnectedBlock { get; set; }
 
     // Get snapped status


### PR DESCRIPTION
Added a quick delay to snapping after grabbing to try and prevent the OnGrab bug listed in PR #63.
- Added a `snappingEnabled` boolean to `SnappedForwarding.cs` to disable snapping immediately after grabbing a block.
- Added a `snappingEnabled` check to OnSnapTriggerEnter to prevent snapping if `snappingEnabled` is false.
- Added `DisableSnapOnGrab()` coroutine called by `OnGrab()` to add a 0.1 second delay to snapping after grabbing.