### PR TITLE
Move root block with snapped child

### DIFF
--- a/Assets/Blocks/Scripts/BlockSnapping.cs
+++ b/Assets/Blocks/Scripts/BlockSnapping.cs
@@ -175,6 +175,25 @@ public class BlockSnapping : MonoBehaviour
             // Set targetPosition values of children (if any)
             UpdateChildBlockPositions(block1);
         }
+
+        ReleaseRootBlock(block1);
+    }
+
+    private void ReleaseRootBlock(GameObject block)
+    {
+        if (block == null) return;
+
+        SnappedForwarding snappedForwarding = block.GetComponentInChildren<SnappedForwarding>();
+        if (snappedForwarding == null) return;
+
+        GameObject rootBlock = snappedForwarding.FindRootBlock(block);
+        if (rootBlock == null) return;
+
+        Rigidbody rootRb = rootBlock.GetComponent<Rigidbody>();
+        if (rootRb != null)
+        {
+            rootRb.constraints = RigidbodyConstraints.None;
+        }
     }
 
     private void UpdateChildBlockPositions(GameObject parentBlock)

--- a/Assets/Blocks/Scripts/BlockSnapping.cs
+++ b/Assets/Blocks/Scripts/BlockSnapping.cs
@@ -186,6 +186,7 @@ public class BlockSnapping : MonoBehaviour
         SnappedForwarding snappedForwarding = block.GetComponentInChildren<SnappedForwarding>();
         if (snappedForwarding == null) return;
 
+        snappedForwarding.IsRootBlock = false; // prevents FindRootBlock from returning this block.
         GameObject rootBlock = snappedForwarding.FindRootBlock(block);
         if (rootBlock == null) return;
 


### PR DESCRIPTION
Adds a simple function, `ReleaseRootBlock()` to `BlockSnapping.cs` that releases the root block's `rb.Constraints` when a block is snapped to it or it's children. This is to prevent what I felt wasn't a desired interaction when you snapped a block to the queue and move your hand around, the queue block wouldn't move with it.