### PR TITLE
reset button now always works

### DIFF
--- a/Assets/Misc/Prefabs/XR Origin (XR Rig).prefab
+++ b/Assets/Misc/Prefabs/XR Origin (XR Rig).prefab
@@ -7816,7 +7816,7 @@ MonoBehaviour:
   rightHandGrabAction: {fileID: 187161793506945269, guid: c348712bda248c246b8c49b3db54643f, type: 3}
   leftHandGrabAction: {fileID: -6131295136447488360, guid: c348712bda248c246b8c49b3db54643f, type: 3}
   playerUIManager: {fileID: 0}
-  disableMenusWhileGrabbing: 0
+  disableMenusWhileGrabbing: 1
   grabSources: []
 --- !u!114 &766790617044663459
 MonoBehaviour:

--- a/Assets/Scripts/Menus/PlayerUIManager.cs
+++ b/Assets/Scripts/Menus/PlayerUIManager.cs
@@ -137,6 +137,8 @@ public class PlayerUIManager : MonoBehaviour
         TurtleMovement turtleMovement = GameObject.Find("/MapSpawner/Turtle").GetComponent<TurtleMovement>();
         if (turtleMovement != null)
         {
+            turtleMovement.canFail = true;
+            turtleMovement.canReset = true;
             turtleMovement.Fail();
         }
         else


### PR DESCRIPTION
- set `canFail` and `canReset` to `true` before `Fail()` call in `PlayerUIManager.ResetTurtle()`.