### PR TITLE
function call block spawning

### DIFF
--- a/Assets/Blocks/Materials/Bright Purple.mat
+++ b/Assets/Blocks/Materials/Bright Purple.mat
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Bright Purple
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_Parent: {fileID: 2100000, guid: 8bc8f266815144b96b5c0882ef7dda74, type: 2}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs: []
+    m_Ints: []
+    m_Floats: []
+    m_Colors:
+    - _Color: {r: 0.9868994, g: 0, b: 1, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Blocks/Materials/Bright Purple.mat.meta
+++ b/Assets/Blocks/Materials/Bright Purple.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ed9ac05816b571a719251b9937f35ffe
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Blocks/Prefabs/Block (Function).prefab
+++ b/Assets/Blocks/Prefabs/Block (Function).prefab
@@ -262,37 +262,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1389943061981320986}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2764345193418972751
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8009763825008059073}
-  m_Layer: 0
-  m_Name: SnapPointTop
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8009763825008059073
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2764345193418972751}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.5, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1389943061981320986}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6632366837083905868
 GameObject:
   m_ObjectHideFlags: 0
@@ -407,9 +376,7 @@ Transform:
   m_LocalScale: {x: 0.5, y: 0.25, z: 0.5}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 3976268369088059121}
   - {fileID: 7695696624973611861}
-  - {fileID: 8009763825008059073}
   - {fileID: 9075289025122379036}
   - {fileID: 3323806906386275171}
   - {fileID: 5703846468437411681}
@@ -564,6 +531,7 @@ MonoBehaviour:
   functionCallPrefab: {fileID: 6713015538121544575, guid: 6624236ae1e177e2cb847d4bf721f9ca, type: 3}
   spawnOffset: {x: 0, y: 1, z: 1}
   FunctionID: 0
+  selectedForSpawnMaterial: {fileID: 2100000, guid: ed9ac05816b571a719251b9937f35ffe, type: 2}
 --- !u!114 &3681838429516486516
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1002,70 +970,3 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!1 &8756861190917617692
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3976268369088059121}
-  - component: {fileID: 8836263195832741215}
-  - component: {fileID: 6478105249058030286}
-  m_Layer: 0
-  m_Name: SnapTriggerTop
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3976268369088059121
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8756861190917617692}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.486, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1389943061981320986}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!65 &8836263195832741215
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8756861190917617692}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 1
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 0.5, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!114 &6478105249058030286
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8756861190917617692}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 65363b0380395e24b9c3462900c6e7c3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  parentBlockSnapping: {fileID: 0}

--- a/Assets/Blocks/Prefabs/Block (Function).prefab
+++ b/Assets/Blocks/Prefabs/Block (Function).prefab
@@ -532,6 +532,7 @@ MonoBehaviour:
   spawnOffset: {x: 0, y: 1, z: 1}
   FunctionID: 0
   selectedForSpawnMaterial: {fileID: 2100000, guid: ed9ac05816b571a719251b9937f35ffe, type: 2}
+  defaultMaterial: {fileID: 2100000, guid: 8bc8f266815144b96b5c0882ef7dda74, type: 2}
 --- !u!114 &3681838429516486516
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Blocks/Scripts/FunctionBlock.cs
+++ b/Assets/Blocks/Scripts/FunctionBlock.cs
@@ -14,18 +14,19 @@ public class FunctionBlock : MonoBehaviour
     public Vector3 spawnOffset;
     public int FunctionID;
     public Material selectedForSpawnMaterial;
-    private Material defaultMaterial;
+    public Material defaultMaterial;
     private PlayerUIManager playerUIManager;
     private bool isHovered = false;
     // Start is called before the first frame update
     void Start()
     {
-      defaultMaterial = GetComponent<Renderer>().material;
       primaryButtonRight.action.started += OnPrimaryButton;
       primaryButtonLeft.action.started += OnPrimaryButton;
       GetComponent<XRGrabInteractable>().hoverEntered.AddListener(OnHoverEntered);
       GetComponent<XRGrabInteractable>().hoverExited.AddListener(OnHoverExited);
       FunctionID = gameObject.GetInstanceID();
+      var FCLabel = transform.Find("BlockLabel/LabelText").gameObject.GetComponent<TextMeshProUGUI>();
+      FCLabel.text = "Function " + FunctionID.ToString();
       playerUIManager = FindObjectOfType<PlayerUIManager>();
     }
 
@@ -36,13 +37,13 @@ public class FunctionBlock : MonoBehaviour
     public void OnHoverEntered(HoverEnterEventArgs hoverEnter){
       isHovered = true;
       //controllerModels.EnableControllerHands(false);
-      Debug.Log("FunctionDefinintionBlock: Hovered");
+      //Debug.Log("FunctionDefinintionBlock: Hovered");
     }
 
     public void OnHoverExited(HoverExitEventArgs hoverExit){
       isHovered = false;
       //controllerModels.EnableControllerHands(true);
-      Debug.Log("FunctionDefinintionBlock: Not Hovered");
+      //Debug.Log("FunctionDefinintionBlock: Not Hovered");
     }
 
     public void OnPrimaryButton(InputAction.CallbackContext ctx)

--- a/Assets/Blocks/Scripts/FunctionBlock.cs
+++ b/Assets/Blocks/Scripts/FunctionBlock.cs
@@ -4,61 +4,74 @@ using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.InputSystem;
 using TMPro;
+using UnityEngine.XR.Interaction.Toolkit;
 
 public class FunctionBlock : MonoBehaviour
 {
-    //public ControllerModels controllerModels;
     public InputActionReference primaryButtonRight;
     public InputActionReference primaryButtonLeft;
     public GameObject functionCallPrefab;
     public Vector3 spawnOffset;
     public int FunctionID;
-
-    //private QueueReading queueReading;
+    public Material selectedForSpawnMaterial;
+    private Material defaultMaterial;
+    private PlayerUIManager playerUIManager;
     private bool isHovered = false;
     // Start is called before the first frame update
     void Start()
     {
-      //controllerModels = GameObject.Find("XR Origin (XR Rig)").GetComponent<ControllerModels>();
-      primaryButtonRight.action.started += onPrimaryButton;
-      primaryButtonLeft.action.started += onPrimaryButton;
-      //queueReading = gameObject.GetComponent<QueueReading>();
+      defaultMaterial = GetComponent<Renderer>().material;
+      primaryButtonRight.action.started += OnPrimaryButton;
+      primaryButtonLeft.action.started += OnPrimaryButton;
+      GetComponent<XRGrabInteractable>().hoverEntered.AddListener(OnHoverEntered);
+      GetComponent<XRGrabInteractable>().hoverExited.AddListener(OnHoverExited);
       FunctionID = gameObject.GetInstanceID();
+      playerUIManager = FindObjectOfType<PlayerUIManager>();
     }
 
     // void onActivation(){
     //     Queue<UnityEvent> blockQueue = queueReading.GetBlockQueueOfUnityEvents();
     // }
 
-    public void OnHoverEntered(){
+    public void OnHoverEntered(HoverEnterEventArgs hoverEnter){
       isHovered = true;
       //controllerModels.EnableControllerHands(false);
-      //Debug.Log("FunctionDefinintionBlock: Hovered");
+      Debug.Log("FunctionDefinintionBlock: Hovered");
     }
 
-    public void OnHoverExited(){
+    public void OnHoverExited(HoverExitEventArgs hoverExit){
       isHovered = false;
       //controllerModels.EnableControllerHands(true);
-      //Debug.Log("FunctionDefinintionBlock: Not Hovered");
+      Debug.Log("FunctionDefinintionBlock: Not Hovered");
     }
 
-    void onPrimaryButton(InputAction.CallbackContext context){
-      if(isHovered){
-        spawnCallBlock();
+    public void OnPrimaryButton(InputAction.CallbackContext ctx)
+    {
+      if(isHovered && playerUIManager != null)
+      {
+        if(playerUIManager.selectedFunctionBlock != this && playerUIManager.selectedFunctionBlock != null) // other function selected
+        {
+          playerUIManager.selectedFunctionBlock.SetSelectedVisual(false);
+          playerUIManager.selectedFunctionBlock = this;
+          playerUIManager.SetFunctionCallButtonStatus(true);
+          SetSelectedVisual(true);
+        }
+        else if(playerUIManager.selectedFunctionBlock == null) // no function selected
+        {
+          playerUIManager.selectedFunctionBlock = this;
+          playerUIManager.SetFunctionCallButtonStatus(true);
+          SetSelectedVisual(true);
+        }
+        else // this function selected
+        {
+          playerUIManager.selectedFunctionBlock = null;
+          playerUIManager.SetFunctionCallButtonStatus(false);
+          SetSelectedVisual(false);
+        }
       }
     }
 
-    void spawnCallBlock(){
-      var transform = GetComponent<Transform>();
-      var blockEntity = GameObject.Find("MoveableEntities/BlockEntity").GetComponent<Transform>();
-      GameObject newFunctionCall = Instantiate(functionCallPrefab, transform.position + spawnOffset, transform.rotation, blockEntity);
-      newFunctionCall.name = "Block (FunctionCall)";
-      FunctionCallBlock fcb = newFunctionCall.AddComponent<FunctionCallBlock>();
-      fcb.functionDefinition = gameObject;
-      var FCLabel = newFunctionCall.GetComponent<Transform>().Find("BlockLabel/LabelText").gameObject.GetComponent<TextMeshProUGUI>();
-      FCLabel.text = "Call " + FunctionID.ToString();
-      fcb.GetComponent<FunctionCallBlock>().FunctionID = FunctionID;
-    }
+    public void SetSelectedVisual(bool status){ GetComponent<Renderer>().material = status ? selectedForSpawnMaterial : defaultMaterial; }
 }
 
 /*

--- a/Assets/Blocks/Scripts/FunctionBlock.cs
+++ b/Assets/Blocks/Scripts/FunctionBlock.cs
@@ -36,12 +36,14 @@ public class FunctionBlock : MonoBehaviour
 
     public void OnHoverEntered(HoverEnterEventArgs hoverEnter){
       isHovered = true;
+      playerUIManager.blockMenuAction.action.Disable();
       //controllerModels.EnableControllerHands(false);
       //Debug.Log("FunctionDefinintionBlock: Hovered");
     }
 
     public void OnHoverExited(HoverExitEventArgs hoverExit){
       isHovered = false;
+      playerUIManager.blockMenuAction.action.Enable();
       //controllerModels.EnableControllerHands(true);
       //Debug.Log("FunctionDefinintionBlock: Not Hovered");
     }

--- a/Assets/Blocks/Scripts/FunctionCallBlock.cs
+++ b/Assets/Blocks/Scripts/FunctionCallBlock.cs
@@ -5,12 +5,12 @@ using UnityEngine.Events;
 
 public class FunctionCallBlock : MonoBehaviour
 {
-    public GameObject functionDefinition;
+    public FunctionBlock functionDefinition;
     public int FunctionID;
 
     void Start(){
         //FunctionID = functionDefinition.GetComponent<FunctionBlock>().FunctionID;
-        FunctionID = functionDefinition.GetInstanceID();
+        FunctionID = functionDefinition.gameObject.GetInstanceID();
     }
 
     // public Queue<UnityEvent> getFunction(){

--- a/Assets/Blocks/Scripts/NewFunctionButton.cs
+++ b/Assets/Blocks/Scripts/NewFunctionButton.cs
@@ -34,7 +34,7 @@ public class NewFunctionButton : MonoBehaviour
 
         //newFunctionDefinitionInstance.AddComponent(typeof(QueueReading));
         FunctionCallBlock fcb = newFunctionCallInstance.AddComponent<FunctionCallBlock>();
-        fcb.functionDefinition = newFunctionDefinitionInstance;
+        fcb.functionDefinition = newFunctionDefinitionInstance.GetComponent<FunctionBlock>();
 
         // BROKEN
         var FCLabel = newFunctionCallInstance.GetComponent<Transform>().Find("BlockLabel/LabelText").gameObject.GetComponent<TextMeshProUGUI>();

--- a/Assets/Misc/Prefabs/PlayerUIManager.prefab
+++ b/Assets/Misc/Prefabs/PlayerUIManager.prefab
@@ -149,7 +149,6 @@ GameObject:
   - component: {fileID: 4950276849472520537}
   - component: {fileID: 5636777924410968202}
   - component: {fileID: 1545302782675530703}
-  - component: {fileID: 551792133008361378}
   m_Layer: 5
   m_Name: FunctionButton
   m_TagString: MenuUIButton
@@ -259,21 +258,6 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
---- !u!114 &551792133008361378
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 196384321620982669}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 449357cc7bf292742ab21bb2065a516e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  blockPrefab: {fileID: 6713015538121544575, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
-  spawnParent: {fileID: 0}
-  spawnOffset: {x: 0, y: 0.5, z: 0}
 --- !u!1 &198650159233208111
 GameObject:
   m_ObjectHideFlags: 0
@@ -4855,9 +4839,11 @@ MonoBehaviour:
   nextLevelButton: {fileID: 114004908926766871}
   endScreenReturnToMenu: {fileID: 7059557852561757490}
   endScreenReturnToMenuAlt: {fileID: 7649715759853756646}
+  functionDefinitionButton: {fileID: 1545302782675530703}
   callFunctionButton: {fileID: 8322343230500934033}
   selectedFunctionBlock: {fileID: 0}
   functionCallPrefab: {fileID: 6713015538121544575, guid: 6624236ae1e177e2cb847d4bf721f9ca, type: 3}
+  functionDefPrefab: {fileID: 6713015538121544575, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
   movementStrength: 2
 --- !u!1 &4104392604732612235
 GameObject:

--- a/Assets/Misc/Prefabs/PlayerUIManager.prefab
+++ b/Assets/Misc/Prefabs/PlayerUIManager.prefab
@@ -4855,6 +4855,9 @@ MonoBehaviour:
   nextLevelButton: {fileID: 114004908926766871}
   endScreenReturnToMenu: {fileID: 7059557852561757490}
   endScreenReturnToMenuAlt: {fileID: 7649715759853756646}
+  callFunctionButton: {fileID: 8322343230500934033}
+  selectedFunctionBlock: {fileID: 0}
+  functionCallPrefab: {fileID: 6713015538121544575, guid: 6624236ae1e177e2cb847d4bf721f9ca, type: 3}
   movementStrength: 2
 --- !u!1 &4104392604732612235
 GameObject:
@@ -6270,7 +6273,6 @@ GameObject:
   - component: {fileID: 2188744539370473466}
   - component: {fileID: 4862665948112155980}
   - component: {fileID: 8322343230500934033}
-  - component: {fileID: 1026917059663226254}
   m_Layer: 5
   m_Name: CallFunctionButton
   m_TagString: MenuUIButton
@@ -6380,21 +6382,6 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
---- !u!114 &1026917059663226254
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5042451634450064373}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 449357cc7bf292742ab21bb2065a516e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  blockPrefab: {fileID: 6713015538121544575, guid: 6624236ae1e177e2cb847d4bf721f9ca, type: 3}
-  spawnParent: {fileID: 0}
-  spawnOffset: {x: 0, y: 0.5, z: 0}
 --- !u!1 &5107869825057593284
 GameObject:
   m_ObjectHideFlags: 0
@@ -8075,7 +8062,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &1604099024351655669
 RectTransform:
   m_ObjectHideFlags: 0

--- a/Assets/Misc/Prefabs/XR Origin (XR Rig).prefab
+++ b/Assets/Misc/Prefabs/XR Origin (XR Rig).prefab
@@ -3440,8 +3440,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.1356, y: 0.0009}
-  m_SizeDelta: {x: 1.1824, y: 0.2347}
+  m_AnchoredPosition: {x: -0.3132, y: 0.0009}
+  m_SizeDelta: {x: 0.2848, y: 0.2347}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &916029174180839867
 CanvasRenderer:
@@ -3481,6 +3481,140 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4161458810355121713
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8249087365625861548}
+  - component: {fileID: 6878505335203259009}
+  - component: {fileID: 3863108993778504067}
+  m_Layer: 0
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8249087365625861548
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4161458810355121713}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.0001}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2591971248122505487}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.237, y: 0.0014}
+  m_SizeDelta: {x: 1, y: 0.2288}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6878505335203259009
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4161458810355121713}
+  m_CullTransparentMesh: 1
+--- !u!114 &3863108993778504067
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4161458810355121713}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: / Select Function Block
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 0.05
+  m_fontSizeBase: 0.05
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0.07172224, y: 0.22841795, z: 0.28467706, w: 0.22493258}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &4239093476469276974
 GameObject:
   m_ObjectHideFlags: 0
@@ -3961,7 +4095,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0.001}
+  m_AnchoredPosition: {x: -0.016, y: 0.001}
   m_SizeDelta: {x: 1, y: 0.2288}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6610553599297008203
@@ -3992,7 +4126,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Block Menu /
+  m_text: "Block Menu / \nSelect Function"
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -4019,8 +4153,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 0.08
-  m_fontSizeBase: 0.08
+  m_fontSize: 0.06
+  m_fontSizeBase: 0.06
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -4890,7 +5024,6 @@ RectTransform:
   m_Children:
   - {fileID: 2633744194892648947}
   - {fileID: 3913625598269274511}
-  - {fileID: 7553083615421408227}
   - {fileID: 2544593856679900764}
   m_Father: {fileID: 2279069874847945284}
   m_LocalEulerAnglesHint: {x: 2.209, y: 0, z: 0}
@@ -5042,140 +5175,6 @@ Transform:
   - {fileID: 3707095308633871339}
   m_Father: {fileID: 7160380118837349379}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5584432944806971489
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7553083615421408227}
-  - component: {fileID: 8280115627760277815}
-  - component: {fileID: 4932929231833231702}
-  m_Layer: 0
-  m_Name: Text
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &7553083615421408227
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5584432944806971489}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.0001}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 8973228327287531015}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.268, y: 0.0014}
-  m_SizeDelta: {x: 1, y: 0.2288}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &8280115627760277815
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5584432944806971489}
-  m_CullTransparentMesh: 1
---- !u!114 &4932929231833231702
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5584432944806971489}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: / [[debug]] Skip Level
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 0.08
-  m_fontSizeBase: 0.08
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 1
-  m_HorizontalAlignment: 2
-  m_VerticalAlignment: 512
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 1
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0.07172224, y: 0.22841795, z: 0.057872787, w: 0.22493258}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &5618279384296649008
 GameObject:
   m_ObjectHideFlags: 0
@@ -6530,8 +6529,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.3267, y: 0.0018}
-  m_SizeDelta: {x: 0.2579, y: 0.2398}
+  m_AnchoredPosition: {x: -0.0015, y: 0.0018}
+  m_SizeDelta: {x: 0.9083, y: 0.2398}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6377653607076944503
 CanvasRenderer:
@@ -7100,6 +7099,7 @@ RectTransform:
   - {fileID: 8478558870274532395}
   - {fileID: 3359768530437726989}
   - {fileID: 7851893973406804087}
+  - {fileID: 8249087365625861548}
   m_Father: {fileID: 2279069874847945284}
   m_LocalEulerAnglesHint: {x: 2.209, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}

--- a/Assets/Scenes/Basic Level View.unity
+++ b/Assets/Scenes/Basic Level View.unity
@@ -3217,6 +3217,9 @@ MonoBehaviour:
   detachTriggered:
     m_PersistentCalls:
       m_Calls: []
+  onGrabChanged:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1001 &418739506
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4161,7 +4164,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e191e20220bc1c7d69b9bbf1f520e86b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  functionDefinition: {fileID: 1811471421}
+  functionDefinition: {fileID: 1811471423}
   FunctionID: 0
 --- !u!114 &495215162
 MonoBehaviour:
@@ -4321,6 +4324,9 @@ MonoBehaviour:
   rSecondaryDetachAction: {fileID: -5510777845572535337, guid: c348712bda248c246b8c49b3db54643f, type: 3}
   lSecondaryDetachAction: {fileID: -9039172889238697684, guid: c348712bda248c246b8c49b3db54643f, type: 3}
   detachTriggered:
+    m_PersistentCalls:
+      m_Calls: []
+  onGrabChanged:
     m_PersistentCalls:
       m_Calls: []
 --- !u!1 &530347939
@@ -5144,6 +5150,9 @@ MonoBehaviour:
   rSecondaryDetachAction: {fileID: -5510777845572535337, guid: c348712bda248c246b8c49b3db54643f, type: 3}
   lSecondaryDetachAction: {fileID: -9039172889238697684, guid: c348712bda248c246b8c49b3db54643f, type: 3}
   detachTriggered:
+    m_PersistentCalls:
+      m_Calls: []
+  onGrabChanged:
     m_PersistentCalls:
       m_Calls: []
 --- !u!1001 &593206051
@@ -6429,6 +6438,9 @@ MonoBehaviour:
   rSecondaryDetachAction: {fileID: -5510777845572535337, guid: c348712bda248c246b8c49b3db54643f, type: 3}
   lSecondaryDetachAction: {fileID: -9039172889238697684, guid: c348712bda248c246b8c49b3db54643f, type: 3}
   detachTriggered:
+    m_PersistentCalls:
+      m_Calls: []
+  onGrabChanged:
     m_PersistentCalls:
       m_Calls: []
 --- !u!1 &869493605 stripped
@@ -7889,6 +7901,9 @@ MonoBehaviour:
   detachTriggered:
     m_PersistentCalls:
       m_Calls: []
+  onGrabChanged:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1001 &984974739
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -8361,6 +8376,9 @@ MonoBehaviour:
   rSecondaryDetachAction: {fileID: -5510777845572535337, guid: c348712bda248c246b8c49b3db54643f, type: 3}
   lSecondaryDetachAction: {fileID: -9039172889238697684, guid: c348712bda248c246b8c49b3db54643f, type: 3}
   detachTriggered:
+    m_PersistentCalls:
+      m_Calls: []
+  onGrabChanged:
     m_PersistentCalls:
       m_Calls: []
 --- !u!1 &1052323941
@@ -9908,6 +9926,9 @@ MonoBehaviour:
   detachTriggered:
     m_PersistentCalls:
       m_Calls: []
+  onGrabChanged:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1 &1238254139 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 6713015538121544575, guid: 0bb9f75a3fde9db698a608e3e97e2c93, type: 3}
@@ -10071,6 +10092,9 @@ MonoBehaviour:
   rSecondaryDetachAction: {fileID: -5510777845572535337, guid: c348712bda248c246b8c49b3db54643f, type: 3}
   lSecondaryDetachAction: {fileID: -9039172889238697684, guid: c348712bda248c246b8c49b3db54643f, type: 3}
   detachTriggered:
+    m_PersistentCalls:
+      m_Calls: []
+  onGrabChanged:
     m_PersistentCalls:
       m_Calls: []
 --- !u!1 &1243985209
@@ -12712,6 +12736,9 @@ MonoBehaviour:
   detachTriggered:
     m_PersistentCalls:
       m_Calls: []
+  onGrabChanged:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1 &1497425985 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 6713015538121544575, guid: d65e5d116d46668db8a491afbdb9f484, type: 3}
@@ -12875,6 +12902,9 @@ MonoBehaviour:
   rSecondaryDetachAction: {fileID: -5510777845572535337, guid: c348712bda248c246b8c49b3db54643f, type: 3}
   lSecondaryDetachAction: {fileID: -9039172889238697684, guid: c348712bda248c246b8c49b3db54643f, type: 3}
   detachTriggered:
+    m_PersistentCalls:
+      m_Calls: []
+  onGrabChanged:
     m_PersistentCalls:
       m_Calls: []
 --- !u!1 &1510684595
@@ -13396,6 +13426,9 @@ MonoBehaviour:
   rSecondaryDetachAction: {fileID: -5510777845572535337, guid: c348712bda248c246b8c49b3db54643f, type: 3}
   lSecondaryDetachAction: {fileID: -9039172889238697684, guid: c348712bda248c246b8c49b3db54643f, type: 3}
   detachTriggered:
+    m_PersistentCalls:
+      m_Calls: []
+  onGrabChanged:
     m_PersistentCalls:
       m_Calls: []
 --- !u!1 &1551710179
@@ -15766,6 +15799,17 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 1389943061981320986, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
   m_PrefabInstance: {fileID: 1811471420}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1811471423 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6362424727914982184, guid: 819c1545583934bb7a1f0e275d024dc7, type: 3}
+  m_PrefabInstance: {fileID: 1811471420}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1811471421}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa675a2c6a3d3aaa5a1538a205afecee, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &1811471432
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -15924,6 +15968,9 @@ MonoBehaviour:
   rSecondaryDetachAction: {fileID: -5510777845572535337, guid: c348712bda248c246b8c49b3db54643f, type: 3}
   lSecondaryDetachAction: {fileID: -9039172889238697684, guid: c348712bda248c246b8c49b3db54643f, type: 3}
   detachTriggered:
+    m_PersistentCalls:
+      m_Calls: []
+  onGrabChanged:
     m_PersistentCalls:
       m_Calls: []
 --- !u!1 &1814067334
@@ -16466,6 +16513,9 @@ MonoBehaviour:
   detachTriggered:
     m_PersistentCalls:
       m_Calls: []
+  onGrabChanged:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1001 &1879083102
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -16952,6 +17002,9 @@ MonoBehaviour:
   detachTriggered:
     m_PersistentCalls:
       m_Calls: []
+  onGrabChanged:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1001 &1903792421
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -17177,6 +17230,9 @@ MonoBehaviour:
   rSecondaryDetachAction: {fileID: -5510777845572535337, guid: c348712bda248c246b8c49b3db54643f, type: 3}
   lSecondaryDetachAction: {fileID: -9039172889238697684, guid: c348712bda248c246b8c49b3db54643f, type: 3}
   detachTriggered:
+    m_PersistentCalls:
+      m_Calls: []
+  onGrabChanged:
     m_PersistentCalls:
       m_Calls: []
 --- !u!1001 &1923688144
@@ -19034,6 +19090,9 @@ MonoBehaviour:
   detachTriggered:
     m_PersistentCalls:
       m_Calls: []
+  onGrabChanged:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1001 &1107197726269526062
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -19507,6 +19566,9 @@ MonoBehaviour:
   rSecondaryDetachAction: {fileID: -5510777845572535337, guid: c348712bda248c246b8c49b3db54643f, type: 3}
   lSecondaryDetachAction: {fileID: -9039172889238697684, guid: c348712bda248c246b8c49b3db54643f, type: 3}
   detachTriggered:
+    m_PersistentCalls:
+      m_Calls: []
+  onGrabChanged:
     m_PersistentCalls:
       m_Calls: []
 --- !u!1660057539 &9223372036854775807

--- a/Assets/Scripts/ExecutionDirector.cs
+++ b/Assets/Scripts/ExecutionDirector.cs
@@ -600,7 +600,7 @@ public class ExecutionDirector : MonoBehaviour
 
         else if (isFunctionCall)
         {
-            GameObject fd = functionCallBlock.functionDefinition;
+            GameObject fd = functionCallBlock.functionDefinition.gameObject;
             FunctionData nextFunctionData = new FunctionData();
             nextFunctionData.blockList = functionBlockLists[functionCallBlock.FunctionID];
             nextFunctionData.instructionPointer = 0;

--- a/Assets/Scripts/Menus/PlayerUIManager.cs
+++ b/Assets/Scripts/Menus/PlayerUIManager.cs
@@ -2,6 +2,7 @@
  Handle level-to-level Player UI + animations
 */
 using System.Collections.Generic;
+using TMPro;
 using Unity.VisualScripting;
 using Unity.XR.CoreUtils;
 using UnityEngine;
@@ -58,6 +59,11 @@ public class PlayerUIManager : MonoBehaviour
     private UISFXManager? uiSFXManager;
     private bool toggleBlockMenu = false;
 
+    [Header("Function Call Spawning")]
+    public Button callFunctionButton;
+    public FunctionBlock? selectedFunctionBlock;
+    public GameObject functionCallPrefab;
+
     void Start()
     {
         pauseMenu.SetActive(true);
@@ -87,11 +93,13 @@ public class PlayerUIManager : MonoBehaviour
         returnToMenuDenyButton.onClick.AddListener(CloseConfirmationWindow);
         returnToMenuConfirmButton.onClick.AddListener(ReturnToLevelSelector);
         nextLevelButton.onClick.AddListener(ContinueToNextLevel);
+        callFunctionButton.onClick.AddListener(SpawnFunctionCall);
         
         // Open Movement Panel on Block Menu at start
         ShowBlockMenuCategory(movementPanel);
 
         uiSFXManager = FindObjectOfType<UISFXManager>();
+        if(xrRig == null){ xrRig = FindObjectOfType<XROrigin>(); }
     }
 
     public float movementStrength = 2.0f;
@@ -146,6 +154,24 @@ public class PlayerUIManager : MonoBehaviour
         {
             Debug.Log("ResetTurtleButton: Can't find Turtle!");
         }
+    }
+
+    public void SetFunctionCallButtonStatus(bool status)
+    {
+        callFunctionButton.interactable = status;
+    }
+
+    void SpawnFunctionCall()
+    {
+      Vector3 spawnOffset = new (0, 0.5f, 0);
+      var blockEntity = GameObject.Find("MoveableEntities/BlockEntity").GetComponent<Transform>();
+      GameObject newFunctionCall = Instantiate(functionCallPrefab, callFunctionButton.transform.position + spawnOffset, callFunctionButton.transform.rotation, blockEntity);
+      newFunctionCall.name = "Block (FunctionCall)";
+      FunctionCallBlock fcb = newFunctionCall.AddComponent<FunctionCallBlock>();
+      fcb.functionDefinition = selectedFunctionBlock;
+      var FCLabel = newFunctionCall.GetComponent<Transform>().Find("BlockLabel/LabelText").gameObject.GetComponent<TextMeshProUGUI>();
+      FCLabel.text = "Call " + selectedFunctionBlock.FunctionID.ToString();
+      fcb.GetComponent<FunctionCallBlock>().FunctionID = selectedFunctionBlock.FunctionID;
     }
 
     public void OpenConfirmationWindow()

--- a/Assets/Scripts/Menus/PlayerUIManager.cs
+++ b/Assets/Scripts/Menus/PlayerUIManager.cs
@@ -60,9 +60,11 @@ public class PlayerUIManager : MonoBehaviour
     private bool toggleBlockMenu = false;
 
     [Header("Function Call Spawning")]
+    public Button functionDefinitionButton;
     public Button callFunctionButton;
     public FunctionBlock? selectedFunctionBlock;
     public GameObject functionCallPrefab;
+    public GameObject functionDefPrefab;
 
     void Start()
     {
@@ -94,6 +96,7 @@ public class PlayerUIManager : MonoBehaviour
         returnToMenuConfirmButton.onClick.AddListener(ReturnToLevelSelector);
         nextLevelButton.onClick.AddListener(ContinueToNextLevel);
         callFunctionButton.onClick.AddListener(SpawnFunctionCall);
+        functionDefinitionButton.onClick.AddListener(SpawnFuctionDefinition);
         
         // Open Movement Panel on Block Menu at start
         ShowBlockMenuCategory(movementPanel);
@@ -172,6 +175,21 @@ public class PlayerUIManager : MonoBehaviour
       var FCLabel = newFunctionCall.GetComponent<Transform>().Find("BlockLabel/LabelText").gameObject.GetComponent<TextMeshProUGUI>();
       FCLabel.text = "Call " + selectedFunctionBlock.FunctionID.ToString();
       fcb.GetComponent<FunctionCallBlock>().FunctionID = selectedFunctionBlock.FunctionID;
+    }
+
+    void SpawnFuctionDefinition()
+    {
+        Vector3 spawnOffset = new (0, 0.5f, 0);
+        var blockEntity = GameObject.Find("MoveableEntities/BlockEntity").GetComponent<Transform>();
+        GameObject newFunction = Instantiate(functionDefPrefab, functionDefinitionButton.transform.position + spawnOffset, functionDefinitionButton.transform.rotation, blockEntity);
+        FunctionBlock functionBlock = newFunction.GetComponent<FunctionBlock>();
+        if(selectedFunctionBlock != null)
+        {
+            selectedFunctionBlock.SetSelectedVisual(false);
+        }
+        functionBlock.SetSelectedVisual(true);
+        SetFunctionCallButtonStatus(true);
+        selectedFunctionBlock = functionBlock;
     }
 
     public void OpenConfirmationWindow()


### PR DESCRIPTION
This PR makes changes to `FunctionBlock`, `FunctionCallBlock`, and `PlayerUIManager` that enables `FunctionBlock`s to be selected, enabling the button in the function menu to spawn a `FunctionCallBlock` with a reference to the selected `FunctionBlock`.

- Removed `AddObject` from `FunctionButton` and `CallFunctionButton`, spawning is now handled directly by `PlayerUIManager`
- Added `public FunctionBlock selectedFunctionBlock` to `PlayerUIManager`. This variable is set or unset whenever a `FunctionBlock` is selected. This is done by hovering over the block and pressing the Primary Button ("B" on the XR Device Simulator).
- `FunctionBlock` now has a unique `Material` for when it is selected.
- When a `FunctionBlock` is selected, and `selectedFunctionBlock` is set, the `CallFunctionButton` will be enabled.
- The function `PlayerUIManager::SpawnFunctionCall()` listens to the `CallFunctionButton` and will create a `FunctionCallBlock` with a reference to `selectedFunctionBlock`.
- When hovering over a `FunctionBlock` the action to open the block menu is disabled, as they are the same button.