### PR TITLE
Disable Thumbnail Cameras

### DIFF
--- a/Assets/Scenes/PlayableLevels/Level3.unity
+++ b/Assets/Scenes/PlayableLevels/Level3.unity
@@ -6986,7 +6986,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!20 &657516157
 Camera:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/PlayableLevels/Level4.unity
+++ b/Assets/Scenes/PlayableLevels/Level4.unity
@@ -6669,7 +6669,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!20 &1272006678
 Camera:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
They were still enabled in level 3 and 4, oops