### PR TITLE
fix/keyboard

### DIFF
--- a/Assets/Blocks/Prefabs/Block (Function).prefab
+++ b/Assets/Blocks/Prefabs/Block (Function).prefab
@@ -535,7 +535,10 @@ MonoBehaviour:
   FunctionID: 0
   selectedForSpawnMaterial: {fileID: 2100000, guid: ed9ac05816b571a719251b9937f35ffe, type: 2}
   defaultMaterial: {fileID: 2100000, guid: 8bc8f266815144b96b5c0882ef7dda74, type: 2}
-  text: {fileID: 1018436606756444959}
+  functionName: 
+  OnNameChanged:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!114 &3681838429516486516
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -935,9 +938,9 @@ MonoBehaviour:
   m_fontSize: 0.2
   m_fontSizeBase: 0.2
   m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 0.08
+  m_fontSizeMax: 0.2
   m_fontStyle: 1
   m_HorizontalAlignment: 2
   m_VerticalAlignment: 512
@@ -950,7 +953,7 @@ MonoBehaviour:
   m_charWidthMaxAdj: 0
   m_enableWordWrapping: 1
   m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
+  m_overflowMode: 1
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1

--- a/Assets/Blocks/Prefabs/Block (FunctionCall).prefab
+++ b/Assets/Blocks/Prefabs/Block (FunctionCall).prefab
@@ -223,9 +223,9 @@ MonoBehaviour:
   m_fontSize: 0.2
   m_fontSizeBase: 0.2
   m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 0.08
+  m_fontSizeMax: 0.2
   m_fontStyle: 1
   m_HorizontalAlignment: 2
   m_VerticalAlignment: 512
@@ -238,7 +238,7 @@ MonoBehaviour:
   m_charWidthMaxAdj: 0
   m_enableWordWrapping: 1
   m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
+  m_overflowMode: 1
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1

--- a/Assets/Blocks/Scripts/FunctionBlock.cs
+++ b/Assets/Blocks/Scripts/FunctionBlock.cs
@@ -93,6 +93,7 @@ public class FunctionBlock : MonoBehaviour
       {
         VRKeys.Keyboard keyboard = FindObjectOfType<VRKeys.Keyboard>();
         keyboard.Enable();
+        keyboard.SetText(functionName);
         ControllerModels cm = FindObjectOfType<ControllerModels>();
         cm.EnableControllerModel(true, true);
         cm.EnableControllerModel(true, false);
@@ -112,6 +113,7 @@ public class FunctionBlock : MonoBehaviour
         keyboard.OnSubmit.AddListener( (submitText) => {
           functionName = submitText;
           textMesh.text = functionName;
+          if (functionName == ""){ textMesh.text = FunctionID.ToString(); }
           OnNameChanged.Invoke(submitText);
           disable_keyboard();
         } );

--- a/Assets/Blocks/Scripts/FunctionCallBlock.cs
+++ b/Assets/Blocks/Scripts/FunctionCallBlock.cs
@@ -14,8 +14,9 @@ public class FunctionCallBlock : MonoBehaviour
         textMesh = GetComponentInChildren<TextMeshProUGUI>();
         //FunctionID = functionDefinition.GetComponent<FunctionBlock>().FunctionID;
         FunctionID = functionDefinition.gameObject.GetInstanceID();
-        functionDefinition.OnNameChanged.AddListener( (newName) => {
-            textMesh.text = $"Call: {newName}";
+        functionDefinition.OnNameChanged.AddListener( (newName) =>
+        {
+            textMesh.text = $"Call: {(newName == "" ? FunctionID : newName)}";
         });
     }
 


### PR DESCRIPTION
I've addressed the two issues brought up when #160 was merged.
- The keyboard will now have the name of the selected function in its text entry field automatically. If the function hasn't been named, it will be empty.
- The `Block (Function)` and `Block (FunctionCall)` have been modified to have automatic font resizing on their labels. It can now support fairly long function names, longer than any user is likely to enter. Currently, there is no hard limit on how much text a player can enter and commit to a function name, but the labels themselves will truncate the text after roughly 120 characters.