### PR TITLE
Disable hand models when grabbing minimap

### DIFF
--- a/Assets/Map/MiniMap/MiniMapBlockSpawner.cs
+++ b/Assets/Map/MiniMap/MiniMapBlockSpawner.cs
@@ -9,8 +9,7 @@ public class MiniMapBlockSpawner : MonoBehaviour
     public GameObject goalObject;
     public TurtleMovement turtle;
     public MapBlockScriptableObject mapValues;
-    public GameObject disableLeftHandModelOnGrab;
-    public GameObject disableRightHandModelOnGrab;
+    public ControllerModels controllerModels;
     public Vector3 startPositionOffset;
     public Vector3 turtleUpdateOffset = new Vector3(-0.25f, -0.25f, -0.25f);
     public float miniMapScale = 0.1f;
@@ -39,9 +38,11 @@ public class MiniMapBlockSpawner : MonoBehaviour
         grabInteractable.selectExited.AddListener(ShowGrabbingHand);
 
         startPositionOffset = (mapValues.blockScale / 2) - CalculateCenterOfMass();
+        controllerModels = FindObjectOfType<ControllerModels>();
     }
     void Update()
     {
+        if(minimapRB == null){ return;  }
         // Return minimap to original position
         if ((initPos - transform.position).magnitude >= 0.08)
         {
@@ -125,24 +126,27 @@ public class MiniMapBlockSpawner : MonoBehaviour
     }
     public void HideGrabbingHand(SelectEnterEventArgs args)
     {
+        if(controllerModels == null){ return; }
+
         if (args.interactorObject.transform.CompareTag("Left Hand"))
         {
-            disableLeftHandModelOnGrab.SetActive(false);
+            controllerModels.EnableControllerModel(true, false);
         }
         else if (args.interactorObject.transform.CompareTag("Right Hand"))
         {
-            disableRightHandModelOnGrab.SetActive(false);
+            controllerModels.EnableControllerModel(true, true);
         }
     }
     public void ShowGrabbingHand(SelectExitEventArgs args)
     {
+        if(controllerModels == null){ return; }
         if (args.interactorObject.transform.CompareTag("Left Hand"))
         {
-            disableLeftHandModelOnGrab.SetActive(true);
+            controllerModels.EnableControllerModel(false, false);
         }
         else if (args.interactorObject.transform.CompareTag("Right Hand"))
         {
-            disableRightHandModelOnGrab.SetActive(true);
+            controllerModels.EnableControllerModel(false, true);
         }
     }
     public void ClearMap()

--- a/Assets/Misc/Prefabs/MiniMapSpawner.prefab
+++ b/Assets/Misc/Prefabs/MiniMapSpawner.prefab
@@ -1,5 +1,36 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &14203895447658484
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2922403554718695172}
+  m_Layer: 0
+  m_Name: AttachPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2922403554718695172
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 14203895447658484}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.459, z: -1.758}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5994844461748421928}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &3842154932197763979
 GameObject:
   m_ObjectHideFlags: 0
@@ -32,7 +63,8 @@ Transform:
   m_LocalPosition: {x: 0, y: 0.911, z: 0.796}
   m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
   m_ConstrainProportionsScale: 1
-  m_Children: []
+  m_Children:
+  - {fileID: 2922403554718695172}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2298146127980593755
@@ -51,8 +83,7 @@ MonoBehaviour:
   goalObject: {fileID: 3548398643600602396, guid: f1ee4ab51e4d2b3a189cf3881dbf2ae0, type: 3}
   turtle: {fileID: 0}
   mapValues: {fileID: 0}
-  disableLeftHandModelOnGrab: {fileID: 0}
-  disableRightHandModelOnGrab: {fileID: 0}
+  controllerModels: {fileID: 0}
   startPositionOffset: {x: 0.125, y: -0.125, z: -0.875}
   turtleUpdateOffset: {x: -0.25, y: -0.25, z: -0.25}
   miniMapScale: 0.08
@@ -185,7 +216,7 @@ MonoBehaviour:
   m_OnDeactivate:
     m_PersistentCalls:
       m_Calls: []
-  m_AttachTransform: {fileID: 0}
+  m_AttachTransform: {fileID: 2922403554718695172}
   m_SecondaryAttachTransform: {fileID: 0}
   m_UseDynamicAttach: 0
   m_MatchAttachPosition: 1

--- a/Assets/Misc/Prefabs/XR Origin (XR Rig).prefab
+++ b/Assets/Misc/Prefabs/XR Origin (XR Rig).prefab
@@ -4737,7 +4737,7 @@ GameObject:
   - component: {fileID: 1025357004983378657}
   m_Layer: 0
   m_Name: Left Controller
-  m_TagString: Untagged
+  m_TagString: Left Hand
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -6242,7 +6242,7 @@ GameObject:
   - component: {fileID: 8743270797115354196}
   m_Layer: 0
   m_Name: Right Controller
-  m_TagString: Untagged
+  m_TagString: Right Hand
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -8791,6 +8791,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: RRayInteractor
       objectReference: {fileID: 0}
+    - target: {fileID: 1787346994484839025, guid: ad818c36731146e994540a1896ad8f24, type: 3}
+      propertyPath: m_TagString
+      value: Right Hand
+      objectReference: {fileID: 0}
     - target: {fileID: 5888765399538998960, guid: ad818c36731146e994540a1896ad8f24, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -8833,7 +8837,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7462879561657043759, guid: ad818c36731146e994540a1896ad8f24, type: 3}
       propertyPath: m_UseForceGrab
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7462879561657043759, guid: ad818c36731146e994540a1896ad8f24, type: 3}
       propertyPath: m_HoverToSelect
@@ -9201,6 +9205,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: LDirectInteractor
       objectReference: {fileID: 0}
+    - target: {fileID: 8841706926471734270, guid: 2fd3e07afe5b461490fb8e314976b1b0, type: 3}
+      propertyPath: m_TagString
+      value: Left Hand
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -9379,6 +9387,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: RDirectInteractor
       objectReference: {fileID: 0}
+    - target: {fileID: 8841706926471734270, guid: 2fd3e07afe5b461490fb8e314976b1b0, type: 3}
+      propertyPath: m_TagString
+      value: Right Hand
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -9400,6 +9412,10 @@ PrefabInstance:
     - target: {fileID: 1787346994484839025, guid: ad818c36731146e994540a1896ad8f24, type: 3}
       propertyPath: m_Name
       value: LRayInteractor
+      objectReference: {fileID: 0}
+    - target: {fileID: 1787346994484839025, guid: ad818c36731146e994540a1896ad8f24, type: 3}
+      propertyPath: m_TagString
+      value: Left Hand
       objectReference: {fileID: 0}
     - target: {fileID: 5888765399538998960, guid: ad818c36731146e994540a1896ad8f24, type: 3}
       propertyPath: m_LocalPosition.x
@@ -9443,7 +9459,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7462879561657043759, guid: ad818c36731146e994540a1896ad8f24, type: 3}
       propertyPath: m_UseForceGrab
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7462879561657043759, guid: ad818c36731146e994540a1896ad8f24, type: 3}
       propertyPath: m_HoverToSelect


### PR DESCRIPTION
Addresses #154

- Modified `MiniMapBlockSpawner` to interact with `ControllerModels` to switch to the XR Controller Model when grabbing the minimap
- Added an attachment point to the `MiniMapBlockSpawner` to keep it from intersecting the model.
- Disabled Force Grab on the `XRRayInteractor`s.

I decided to disable Force Grab because having the blocks always automatically brought right to my hands often made the interaction frustrating, especially when trying to manipulate large stacks. I figure that either Force Grab should be left turned off, or an interaction pattern, like holding down the trigger, or some other button, should be created to allow the user to selectively enable it.