### PR TITLE
Deleting blocks should now reset snap status of other block and delete wires.

### DIFF
--- a/Assets/Blocks/Scripts/BlockSnapping.cs
+++ b/Assets/Blocks/Scripts/BlockSnapping.cs
@@ -457,7 +457,7 @@ public class BlockSnapping : MonoBehaviour
         //queueReading?.ReadQueue();
     }
 
-    private void ResetSnapStatusOnOtherBlock(GameObject otherBlock)
+    public void ResetSnapStatusOnOtherBlock(GameObject otherBlock)
     {
         // Find the SnapTriggerBottom on the other block
         Transform otherSnapTriggerBottom = otherBlock.transform.Find("SnapTriggerBottom");

--- a/Assets/Blocks/Scripts/DeletionBoundary.cs
+++ b/Assets/Blocks/Scripts/DeletionBoundary.cs
@@ -18,6 +18,22 @@ public class DeletionBoundary : MonoBehaviour
             return;
         }
 
+        if (other.gameObject.CompareTag("Block"))
+        {
+            Joint joint = other.GetComponent<Joint>();
+            if (joint != null && joint.connectedBody != null)
+            {
+                GameObject parentBlock = joint.connectedBody.gameObject;
+                BlockSnapping parentSnapping = parentBlock.GetComponent<BlockSnapping>();
+                if (parentSnapping != null)
+                {
+                    parentSnapping.ResetSnapStatusOnOtherBlock(parentBlock);
+                    Rigidbody parentRb = parentBlock.GetComponent<Rigidbody>();
+                    parentSnapping.DestroyWire(parentRb);
+                }
+            }
+        }
+
         Destroy(other.gameObject);
         objectDestroyedEvent.Invoke();
     }


### PR DESCRIPTION
Addressing #149 and #150 

Changes:

- Added "Block" tag check to `DeletionBoundary.cs`, blocks passed will retrieve their parent block then call `BlockSnapping.ResetSnapStatusOnOtherBlock(parentBlock)` and `BlockSnapping.DeleteWire(ParentRb)` to prevent the above issues.