### PR TITLE
Blocks now rotate to face the player

### DIFF
--- a/Assets/Blocks/Scripts/BlockSnapping.cs
+++ b/Assets/Blocks/Scripts/BlockSnapping.cs
@@ -651,7 +651,7 @@ public class BlockSnapping : MonoBehaviour
         Debug.Log("UpdateBlockPosition: Initial Position - X: " + initialPosition.x + ", Y: " + initialPosition.y + ", Z: " + initialPosition.z);
 
         // Calculate circular offset of block to reposition additional columns along a circular area
-        Transform playerTransform = GameObject.Find("XR Origin (XR Rig)").transform;
+        Transform playerTransform = GameObject.Find("XR Origin (XR Rig)").transform; // The player's current position
         Vector3 playerPosition = playerTransform.position;
         Vector3 parentPosition = initialRootBlockPosition;
 
@@ -659,16 +659,15 @@ public class BlockSnapping : MonoBehaviour
         Vector3 parentToPlayer = (playerPosition - parentPosition).normalized;
         parentToPlayer.y = 0;
 
-        // Radius of circular area
+        // Radius of circular arc (distance from root to player)
         float radius = Vector3.Distance(playerPosition, parentPosition);
 
-        // Calculate the new circular position based on root position following circular shape of radius = distance from root block.
+        // Calculate new position on circular arc for this block
         Vector3 adjustedPosition = GetCircularOffset(playerPosition, parentToPlayer, radius, adjustPositionX, 10f); // Adjust the float number to modify distance between columns!!!
 
-        // Maintain y position from offset
+        // Apply y-offset to maintain block stack
         adjustedPosition.y = initialRootBlockPosition.y + (adjustPositionY * yBlockOffset);
 
-        currentRb.transform.position = adjustedPosition;
         Debug.Log("UpdateBlockPosition: Adjusted Position - X: " + adjustedPosition.x + ", Y: " + adjustedPosition.y + ", Z: " + adjustedPosition.z);
 
         // Apply the new position to the block
@@ -707,7 +706,7 @@ public class BlockSnapping : MonoBehaviour
         // Determine base angle
         float baseAngle = Mathf.Atan2(forward.x, forward.z) * Mathf.Rad2Deg;
 
-        // Calculate the angle for this column
+        // Calculate the angle for this column (+180f because it was behind the player)
         float angle = baseAngle + 180f + (xOffset * angleStepDegrees);
 
         // Convert angle back to radians

--- a/Assets/Blocks/Scripts/BlockSnapping.cs
+++ b/Assets/Blocks/Scripts/BlockSnapping.cs
@@ -20,7 +20,6 @@ public class BlockSnapping : MonoBehaviour
     private AudioSource audioSource;
 
 
-
     private void Awake()
     {
         // Collision Forwarding active
@@ -665,7 +664,11 @@ public class BlockSnapping : MonoBehaviour
         //Debug.Log("UpdateBlockPosition: Block Position Updated!");
 
         // Face the player on update. 
-        currentRb.transform.rotation = Quaternion.Euler(0, 0, 0); //Quaternion.LookRotation(playerLocation)
+        Transform playerPosition = GameObject.Find("XR Origin (XR Rig)").transform;
+        Vector3 directionToPlayer = playerPosition.position - currentRb.transform.position;
+        directionToPlayer.y = 0; // Ignore Y direction to keep blocks straight.
+
+        currentRb.transform.rotation = Quaternion.LookRotation(-directionToPlayer); //Quaternion.LookRotation(playerLocation)
         //Debug.Log("UpdateBlockPosition: Block Rotation Reset!");
 
         // Recreate the joint to reattach the block to its parent

--- a/Assets/Blocks/Scripts/BlockSnapping.cs
+++ b/Assets/Blocks/Scripts/BlockSnapping.cs
@@ -664,8 +664,8 @@ public class BlockSnapping : MonoBehaviour
         currentRb.transform.position = adjustedPosition;
         //Debug.Log("UpdateBlockPosition: Block Position Updated!");
 
-        // Reset rotation (probably unnecessary)
-        currentRb.transform.rotation = Quaternion.Euler(0, 0, 0);
+        // Face the player on update. 
+        currentRb.transform.rotation = Quaternion.Euler(0, 0, 0); //Quaternion.LookRotation(playerLocation)
         //Debug.Log("UpdateBlockPosition: Block Rotation Reset!");
 
         // Recreate the joint to reattach the block to its parent

--- a/Assets/Blocks/Scripts/BlockSnapping.cs
+++ b/Assets/Blocks/Scripts/BlockSnapping.cs
@@ -660,10 +660,13 @@ public class BlockSnapping : MonoBehaviour
         parentToPlayer.y = 0;
 
         // Radius of circular arc (distance from root to player)
-        float radius = Vector3.Distance(playerPosition, parentPosition);
+        float radius = Vector2.Distance(
+            new Vector2(playerPosition.x, playerPosition.z),
+            new Vector2(parentPosition.x, parentPosition.z)
+        );
 
         // Calculate new position on circular arc for this block
-        Vector3 adjustedPosition = GetCircularOffset(playerPosition, parentToPlayer, radius, adjustPositionX, 10f); // Adjust the float number to modify distance between columns!!!
+        Vector3 adjustedPosition = GetCircularOffset(playerPosition, parentToPlayer, radius, adjustPositionX, 15f); // Adjust the float number to modify distance between columns!!!
 
         // Apply y-offset to maintain block stack
         adjustedPosition.y = initialRootBlockPosition.y + (adjustPositionY * yBlockOffset);

--- a/Assets/Blocks/Scripts/BlockSnapping.cs
+++ b/Assets/Blocks/Scripts/BlockSnapping.cs
@@ -134,7 +134,7 @@ public class BlockSnapping : MonoBehaviour
         topRb.constraints = RigidbodyConstraints.None;
         bottomRb.constraints = RigidbodyConstraints.None;
 
-        // Reset X and Z rotations for both blocks IF blocks are NOT wires
+        // Reset X and Z rotations for both blocks IF blocks are NOT wires (Redundant? Remove on cleanup)
         if (!block1.name.Contains("Wire"))
         {
             block1.transform.rotation = Quaternion.Euler(0, block1.transform.rotation.eulerAngles.y, 0);

--- a/Assets/Blocks/Scripts/BlockSnapping.cs
+++ b/Assets/Blocks/Scripts/BlockSnapping.cs
@@ -664,9 +664,10 @@ public class BlockSnapping : MonoBehaviour
             new Vector2(playerPosition.x, playerPosition.z),
             new Vector2(parentPosition.x, parentPosition.z)
         );
+        radius = Mathf.Max(radius, 2f); // Minimum 2
 
         // Calculate new position on circular arc for this block
-        Vector3 adjustedPosition = GetCircularOffset(playerPosition, parentToPlayer, radius, adjustPositionX, 15f); // Adjust the float number to modify distance between columns!!!
+        Vector3 adjustedPosition = GetCircularOffset(playerPosition, parentToPlayer, radius, adjustPositionX, 20f); // Adjust the float number to modify distance between columns!!!
 
         // Apply y-offset to maintain block stack
         adjustedPosition.y = initialRootBlockPosition.y + (adjustPositionY * yBlockOffset);

--- a/Assets/Blocks/Scripts/SnappedForwarding.cs
+++ b/Assets/Blocks/Scripts/SnappedForwarding.cs
@@ -175,7 +175,6 @@ public class SnappedForwarding : MonoBehaviour
             rb.useGravity = false;
             rb.velocity = Vector3.zero;
             rb.angularVelocity = Vector3.zero;
-            rb.transform.rotation = Quaternion.Euler(0, 0, 0);
             rb.constraints = RigidbodyConstraints.FreezePosition | RigidbodyConstraints.FreezeRotation;
         }
         else if (hasSnapped)
@@ -184,7 +183,6 @@ public class SnappedForwarding : MonoBehaviour
             rb.useGravity = false;
             rb.velocity = Vector3.zero;
             rb.angularVelocity = Vector3.zero;
-            rb.transform.rotation = Quaternion.Euler(0, 0, 0);
             // No changes to rb.constraints
         }
         else if (canSnap && !hasSnapped)
@@ -199,7 +197,6 @@ public class SnappedForwarding : MonoBehaviour
             rb.useGravity = false;
             rb.velocity = Vector3.zero;
             rb.angularVelocity = Vector3.zero;
-            rb.transform.rotation = Quaternion.Euler(0, 0, 0);
             rb.constraints = RigidbodyConstraints.FreezePosition | RigidbodyConstraints.FreezeRotation;
         }
 
@@ -227,10 +224,6 @@ public class SnappedForwarding : MonoBehaviour
                     // Update position to match the X and Z of the parent block
                     Vector3 parentPosition = otherRbParent.transform.position;
                     rb.transform.position = new Vector3(parentPosition.x, rb.transform.position.y, parentPosition.z);
-
-                    // Reset rotation to 0
-                    rb.transform.rotation = Quaternion.Euler(0, 0, 0);
-                    //Debug.Log($"Physics Update: Position/Rotation reset");
 
                     // Update position to match the X and Z of the parent block, realign SnapPointTop with SnapPointBottom
                     Transform snapPointTop = rb.transform.Find("SnapPointTop");

--- a/Assets/Blocks/Scripts/SnappedForwarding.cs
+++ b/Assets/Blocks/Scripts/SnappedForwarding.cs
@@ -77,6 +77,8 @@ public class SnappedForwarding : MonoBehaviour
     {
         Debug.Log($"IsLoopedBlock called: thisBlock.connectedBody = {thisBlock?.name ?? "null"}, otherBlock = {otherBlock?.name ?? "null"}");
 
+        bool iteratedOnce = false;
+
         if (thisBlock == null)
         {
             return false;
@@ -91,6 +93,11 @@ public class SnappedForwarding : MonoBehaviour
                 return true;
             }
 
+            if (currentBlock == otherBlock && iteratedOnce == true)
+            {
+                return true;
+            }
+
             SnappedForwarding snappedForwarding = currentBlock.GetComponentInChildren<SnappedForwarding>();
             if (snappedForwarding != null && snappedForwarding.ConnectedBlock != null)
             {
@@ -100,6 +107,8 @@ public class SnappedForwarding : MonoBehaviour
             {
                 break;
             }
+
+            iteratedOnce = true;
         }
 
         return false;

--- a/Assets/Blocks/Scripts/WireLine.cs
+++ b/Assets/Blocks/Scripts/WireLine.cs
@@ -20,8 +20,9 @@ public class WireLine : MonoBehaviour
         Vector3 p0 = startPoint.position;
         Vector3 p3 = endPoint.position;
 
-        Vector3 dir = (p3 - p0).normalized;
-        Vector3 offsetX = new Vector3(0.25f, 0, 0); // 0.5 in X
+        Vector3 dir = (p3 - p0).normalized; // Unused now?
+        float midX = (p3.x - p0.x) / 2f;
+        Vector3 offsetX = new Vector3(midX, 0, 0); // 0.5 in X
         Vector3 offsetY = new Vector3(0, 1.0f, 0); // 1.0 in Y
 
         Vector3 p1 = p0 + offsetX;

--- a/Assets/Blocks/Scripts/WireLine.cs
+++ b/Assets/Blocks/Scripts/WireLine.cs
@@ -22,8 +22,9 @@ public class WireLine : MonoBehaviour
 
         Vector3 dir = (p3 - p0).normalized; // Unused now?
         float midX = (p3.x - p0.x) / 2f;
-        Vector3 offsetX = new Vector3(midX, 0, 0); // 0.5 in X
-        Vector3 offsetY = new Vector3(0, 1.0f, 0); // 1.0 in Y
+        float midZ = (p3.z - p0.z) / 2f;
+        Vector3 offsetX = new Vector3(midX, 0, midZ); // Move to midpoint (along x and z-axes) between two blocks
+        Vector3 offsetY = new Vector3(0, 1.0f, 0); // Move to y-axis of child block
 
         Vector3 p1 = p0 + offsetX;
         Vector3 p2 = p1 + offsetY;


### PR DESCRIPTION
Addressing #165, as per Tyler's dad's request.

Blocks should now rotate to face the player upon release. Additionally, block columns will now rotate about a circular arc for better viewability.

Changes (Initial):

- Updated the `BlockSnapping.UpdateBlockPosition()` function to adjust block rotation based on the direction of the player.
- Added new `BlockSnapping.GetCircularOffset()` function to calculate column position based on a circular arc using a radius calculated based on the distance between the player (position of "`XR Origin (XR Rig)`" game object) and root block. **The spread between columns can be adjusted by changing the float number passed to this funciton**.
- Updated the `BlockSnapping.UpdateBlockPosition()` function to use `GetCircularOffset()` to adjust block position along the circular arc.

Changes (06/01/2025):

- Merged changes included in PR #170 
- Addressed the issue described as "would it be possible for the stack to not be pushed away when they're released? maybe find a way to have the circle placement calculation have a slightly smaller radius than it currently resolves to?" by removing y-axis from radius calculation.
- Added `midZ` float number to `WireLine.cs` to better draw line in 3-dimensions.
- Added an additional check to `SnappedForwarding.cs`'s IsLoopedBlock() to check if `otherBlock` is attempting to snap to `otherBlock` (previously only did this for `thisBlock`). Fixed an issue I encountered.

Changes (06/02/2025):

- Added minimum radius value (currently 2)
- Increased AngleStepDegrees to 20 (from 15)

Known Issues:

- Due to blocks positioning about the circular arc, very large quantities of blocks will loop into the root block, causing physics issues. I have not addressed this yet, since it isn't likely to happen.
- Releasing a block stack with >1 columns very close to the player could cause blocks to clip into each other, due to the distance between columns being too small.