### PR TITLE
Fix/Block Rotation Bugs

### DIFF
--- a/Assets/Blocks/Scripts/BlockSnapping.cs
+++ b/Assets/Blocks/Scripts/BlockSnapping.cs
@@ -134,7 +134,7 @@ public class BlockSnapping : MonoBehaviour
         topRb.constraints = RigidbodyConstraints.None;
         bottomRb.constraints = RigidbodyConstraints.None;
 
-        // Reset X and Z rotations for both blocks IF blocks are NOT wires
+        // Reset X and Z rotations for both blocks IF blocks are NOT wires (Redundant? Remove on cleanup)
         if (!block1.name.Contains("Wire"))
         {
             block1.transform.rotation = Quaternion.Euler(0, block1.transform.rotation.eulerAngles.y, 0);

--- a/Assets/Blocks/Scripts/SnappedForwarding.cs
+++ b/Assets/Blocks/Scripts/SnappedForwarding.cs
@@ -175,7 +175,6 @@ public class SnappedForwarding : MonoBehaviour
             rb.useGravity = false;
             rb.velocity = Vector3.zero;
             rb.angularVelocity = Vector3.zero;
-            rb.transform.rotation = Quaternion.Euler(0, 0, 0);
             rb.constraints = RigidbodyConstraints.FreezePosition | RigidbodyConstraints.FreezeRotation;
         }
         else if (hasSnapped)
@@ -184,7 +183,6 @@ public class SnappedForwarding : MonoBehaviour
             rb.useGravity = false;
             rb.velocity = Vector3.zero;
             rb.angularVelocity = Vector3.zero;
-            rb.transform.rotation = Quaternion.Euler(0, 0, 0);
             // No changes to rb.constraints
         }
         else if (canSnap && !hasSnapped)
@@ -199,7 +197,6 @@ public class SnappedForwarding : MonoBehaviour
             rb.useGravity = false;
             rb.velocity = Vector3.zero;
             rb.angularVelocity = Vector3.zero;
-            rb.transform.rotation = Quaternion.Euler(0, 0, 0);
             rb.constraints = RigidbodyConstraints.FreezePosition | RigidbodyConstraints.FreezeRotation;
         }
 
@@ -227,10 +224,6 @@ public class SnappedForwarding : MonoBehaviour
                     // Update position to match the X and Z of the parent block
                     Vector3 parentPosition = otherRbParent.transform.position;
                     rb.transform.position = new Vector3(parentPosition.x, rb.transform.position.y, parentPosition.z);
-
-                    // Reset rotation to 0
-                    rb.transform.rotation = Quaternion.Euler(0, 0, 0);
-                    //Debug.Log($"Physics Update: Position/Rotation reset");
 
                     // Update position to match the X and Z of the parent block, realign SnapPointTop with SnapPointBottom
                     Transform snapPointTop = rb.transform.Find("SnapPointTop");

--- a/Assets/Blocks/Scripts/WireLine.cs
+++ b/Assets/Blocks/Scripts/WireLine.cs
@@ -20,8 +20,9 @@ public class WireLine : MonoBehaviour
         Vector3 p0 = startPoint.position;
         Vector3 p3 = endPoint.position;
 
-        Vector3 dir = (p3 - p0).normalized;
-        Vector3 offsetX = new Vector3(0.25f, 0, 0); // 0.5 in X
+        Vector3 dir = (p3 - p0).normalized; // Unused now?
+        float midX = (p3.x - p0.x) / 2f;
+        Vector3 offsetX = new Vector3(midX, 0, 0); // 0.5 in X
         Vector3 offsetY = new Vector3(0, 1.0f, 0); // 1.0 in Y
 
         Vector3 p1 = p0 + offsetX;


### PR DESCRIPTION
Addressing #168 and #169.

Made minor fixes to address issues caused by PR #166.

- Removed deprecated code that zeroed out block rotation in some cases.
- Added midX variable to WireLine.cs's LateUpdate() function to calculate mid x-coordinate distance between blocks to improve the line's visual connection.