### PR TITLE
block count doesn't count function definitions

### DIFF
--- a/Assets/Scripts/ExecutionDirector.cs
+++ b/Assets/Scripts/ExecutionDirector.cs
@@ -633,10 +633,11 @@ public class ExecutionDirector : MonoBehaviour
         GrabFunctionsInScene();
 
         int blocksAllQueues = mainBlockList.Count;
-        foreach(var fbl in functionBlockLists)
-        {
-            blocksAllQueues += fbl.Value.Count;
-        }
+        // Commented out because we only want to count the main queue blocks.
+        // foreach(var fbl in functionBlockLists)
+        // {
+        //     blocksAllQueues += fbl.Value.Count;
+        // }
         handBoundUI.SetBlockCount(blocksAllQueues);
     }
 


### PR DESCRIPTION
This PR is really simple. All I did was comment out the loop in `ExecutionDirector::OnSnapEvent()` that counts the function definition blocks to include them in the block count.